### PR TITLE
ci: add hand-written JS files to workflow path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ on:
       - 'deny.toml'
       - 'vitest.config.mts'
       - 'codecov.yml'
+      - 'streams.js'
+      - 'streams.d.ts'
+      - 'index.mjs'
+      - 'index.d.mts'
   pull_request:
     branches: [develop]
     paths:
@@ -31,6 +35,10 @@ on:
       - 'deny.toml'
       - 'vitest.config.mts'
       - 'codecov.yml'
+      - 'streams.js'
+      - 'streams.d.ts'
+      - 'index.mjs'
+      - 'index.d.mts'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -8,6 +8,10 @@ on:
       - "__test__/**/*.bench.ts"
       - "vitest.config.mts"
       - ".github/workflows/codspeed.yml"
+      - "streams.js"
+      - "streams.d.ts"
+      - "index.mjs"
+      - "index.d.mts"
   pull_request:
     branches: [develop]
     paths:
@@ -15,6 +19,10 @@ on:
       - "__test__/**/*.bench.ts"
       - "vitest.config.mts"
       - ".github/workflows/codspeed.yml"
+      - "streams.js"
+      - "streams.d.ts"
+      - "index.mjs"
+      - "index.d.mts"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

- Add `streams.js`, `streams.d.ts`, `index.mjs`, and `index.d.mts` to path filters in CI and CodSpeed workflows
- These hand-written JS/TS files were missing from the trigger paths, meaning changes to them would not trigger CI or benchmark runs
- `codeql.yml` already uses glob patterns (`**/*.js`, `**/*.ts`) that cover these files, so no changes were needed there

### Workflows updated

- `.github/workflows/ci.yml` — added 4 files to both `push` and `pull_request` path filters
- `.github/workflows/codspeed.yml` — added 4 files to both `push` and `pull_request` path filters

Closes #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * 自動テストおよびパフォーマンス測定ワークフローの実行条件を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->