### PR TITLE
ci(codeql): suppress rust/access-invalid-pointer false positives

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,5 @@
+name: "zflate CodeQL config"
+
+query-filters:
+  - exclude:
+      id: rust/access-invalid-pointer

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,7 @@ on:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
       - '.github/workflows/codeql.yml'
+      - '.github/codeql/**'
   pull_request:
     branches: [develop]
     paths:
@@ -23,6 +24,7 @@ on:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
       - '.github/workflows/codeql.yml'
+      - '.github/codeql/**'
   schedule:
     - cron: '0 6 * * 1' # Weekly Monday 6 AM UTC
 
@@ -57,4 +59,5 @@ jobs:
       - uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4
         with:
           languages: ${{ matrix.language }}
+          config-file: .github/codeql/codeql-config.yml
       - uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4


### PR DESCRIPTION
## Summary

- Add CodeQL configuration file (`.github/codeql/codeql-config.yml`) that excludes the `rust/access-invalid-pointer` query
- Reference the config from the CodeQL workflow init step
- Add `.github/codeql/**` to workflow path triggers so config changes trigger analysis

All 8 `rust/access-invalid-pointer` alerts have been dismissed as false positives. The project exclusively uses safe Rust with well-maintained crate wrappers (zstd, flate2, brotli) — no `unsafe` blocks exist in the codebase. Pointer safety is handled by RAII and Rust's ownership model within these crates, making these alerts noise rather than actionable findings.

Closes #55