### PR TITLE
fix(exports): add ./streams subpath export to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,16 @@
         "default": "./index.js"
       },
       "browser": "./browser.js"
+    },
+    "./streams": {
+      "import": {
+        "types": "./streams.d.ts",
+        "default": "./streams.js"
+      },
+      "require": {
+        "types": "./streams.d.ts",
+        "default": "./streams.js"
+      }
     }
   },
   "files": [


### PR DESCRIPTION
## Summary

- Add `./streams` subpath export to `package.json` enabling `import { createGzipCompressStream } from 'zflate/streams'`
- Both `import` and `require` conditions point to `./streams.js` with types at `./streams.d.ts`

Closes #48

## Test plan

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (121 tests)
- [x] `cargo test` passes
- [x] `cargo clippy` passes