### PR TITLE
fix(dx): add ./streams subpath export to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,16 @@
         "default": "./index.js"
       },
       "browser": "./browser.js"
+    },
+    "./streams": {
+      "import": {
+        "types": "./streams.d.ts",
+        "default": "./streams.js"
+      },
+      "require": {
+        "types": "./streams.d.ts",
+        "default": "./streams.js"
+      }
     }
   },
   "files": [


### PR DESCRIPTION
## Summary

- Add `./streams` subpath export to `package.json` so users can import streaming APIs directly via `import { createGzipCompressStream } from 'zflate/streams'`
- Both `import` and `require` conditions point to `streams.js` / `streams.d.ts` since `streams.js` uses CommonJS which works for both via Node.js CJS-ESM interop

Closes #48

## Checklist

- [x] `pnpm run check` (Biome lint) passes
- [x] `pnpm run build` (napi-rs build) passes
- [x] `pnpm run typecheck` (TypeScript) passes
- [x] `pnpm test` (Vitest — 121 tests) passes
- [x] `pnpm run publint` (package validation) passes