### PR TITLE
ci: add cargo-audit to dependency audit pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,12 @@ jobs:
         run: pnpm audit --prod
       - name: Audit Rust dependencies
         uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@c12d62a803cbdfe2e7263af15f5a9548065cb4f2
+        with:
+          tool: cargo-audit
+      - name: Run cargo audit
+        run: cargo audit
 
   rust-lint:
     name: Rust Lint


### PR DESCRIPTION
## Summary

- Add `cargo-audit` as an additional Rust dependency security check in the CI audit job
- Uses `taiki-e/install-action` (same pinned version already used in the coverage job) to install `cargo-audit`, then runs `cargo audit` against the RustSec Advisory Database
- Complements the existing `cargo-deny` check: `cargo-deny` covers licenses, bans, and sources in addition to advisories, while `cargo-audit` provides a dedicated, up-to-date scan against the RustSec database with detailed vulnerability information

Closes #50