### PR TITLE
docs: enhance README with examples, comparison table, and migration guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,14 +188,16 @@ const decompressed = gzipDecompress(compressed);
 | zstd | ✅ | ❌ | ❌ | ✅* |
 | gzip/deflate | ✅ | ✅ | ✅ | ✅ |
 | brotli | ✅ | ❌ | ❌ | ✅ |
-| Streaming | ✅ | ❌ | ✅ | ✅ |
-| Browser/WASM | ✅ | ✅ | ✅ | ❌ |
-| Deno/Bun | ✅ | ❌ | ✅ | ❌ |
+| Web Streams API | ✅ | ❌ | ❌ | ❌ |
+| Streaming | ✅ | ✅† | ✅ | ✅ |
+| Browser | ✅ | ✅ | ✅ | ❌ |
+| Deno/Bun | ✅ | ✅ | ✅ | ❌ |
 | Native performance | ✅ | ❌ | ❌ | ✅ |
 | TypeScript | ✅ | ✅ | ✅ | ✅ |
 | Zero JS deps | ✅ | ✅ | ✅ | ✅ |
 
 \* Node.js ≥ 22.15 (experimental)
+† Chunked mode via `Inflate`/`Deflate` classes, not Web Streams API
 
 ## Migration
 


### PR DESCRIPTION
## Summary

- Added npm downloads and codecov badges
- Added gzip and brotli quick start examples alongside the existing zstd example
- Added a "Browser Usage" section with WASM usage example and initialization note
- Added a "Comparison with Alternatives" table comparing zflate with pako, fflate, and node:zlib
- Added a "Migration" section with diff-style examples for migrating from pako and node:zlib

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション

* Quick Start に gzip、brotli、zstd の使用例を追加
* ブラウザ利用方法と WASM 自動初期化に関する新規セクションを追加
* 代替ツール比較表とマイグレーション手順（他のライブラリからの乗り換え方法）を追加
* npm ダウンロードと Codecov バッジを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->