### PR TITLE
perf(wasm): add WASM binary size reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,19 @@ jobs:
           sudo apt-get update && sudo apt-get install -y binaryen
           pnpm run optimize:wasm
 
+      - name: Report WASM binary size
+        if: matrix.settings.target == 'wasm32-wasip1-threads'
+        run: |
+          WASM_FILE=$(ls zflate.*.wasm 2>/dev/null | head -1)
+          if [ -n "$WASM_FILE" ]; then
+            SIZE=$(stat -c%s "$WASM_FILE" 2>/dev/null || stat -f%z "$WASM_FILE")
+            echo "### WASM Binary Size" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| File | Size |" >> $GITHUB_STEP_SUMMARY
+            echo "|------|------|" >> $GITHUB_STEP_SUMMARY
+            echo "| $WASM_FILE | $(( SIZE / 1024 )) KB |" >> $GITHUB_STEP_SUMMARY
+          fi
+
       - name: Upload artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ zstdCompress(data, -1);
 
 `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-gnu`, `aarch64-unknown-linux-musl`, `x86_64-pc-windows-msvc`, `aarch64-pc-windows-msvc`
 
+<<<<<<< HEAD
 ## Browser Usage
 
 zflate works in browsers via WASM. Use a bundler like Vite, webpack, or esbuild, or import directly from a CDN:
@@ -222,6 +223,10 @@ const decompressed = gzipDecompress(compressed);
 + const compressed = gzipCompress(data);
 + const decompressed = gzipDecompress(compressed);
 ```
+
+### WASM bundle size
+
+The WASM binary (`wasm32-wasip1-threads`) is optimized with `wasm-opt -O3` during the build process. Binary size is tracked and reported in CI on every build — check the latest [CI run summary](https://github.com/derodero24/zflate/actions/workflows/ci.yml) for current numbers.
 
 ## Benchmarks
 

--- a/scripts/optimize-wasm.js
+++ b/scripts/optimize-wasm.js
@@ -55,6 +55,9 @@ if (wasmFiles.length === 0) {
 
 console.log(`Optimizing ${wasmFiles.length} WASM file(s) with wasm-opt ${optLevel}...`);
 
+let totalOriginal = 0;
+let totalOptimized = 0;
+
 for (const wasmFile of wasmFiles) {
   const basename = path.basename(wasmFile);
   const originalSize = fs.statSync(wasmFile).size;
@@ -73,6 +76,9 @@ for (const wasmFile of wasmFiles) {
     console.log(
       `  ${basename}: ${formatBytes(originalSize)} -> ${formatBytes(optimizedSize)} (${reduction}% smaller)`,
     );
+
+    totalOriginal += originalSize;
+    totalOptimized += optimizedSize;
   } catch (err) {
     // Clean up temp file on failure
     const tmpFile = `${wasmFile}.opt`;
@@ -84,6 +90,12 @@ for (const wasmFile of wasmFiles) {
   }
 }
 
+if (wasmFiles.length > 1) {
+  const totalReduction = (((totalOriginal - totalOptimized) / totalOriginal) * 100).toFixed(1);
+  console.log(
+    `  Total: ${formatBytes(totalOriginal)} -> ${formatBytes(totalOptimized)} (${totalReduction}% smaller)`,
+  );
+}
 console.log('WASM optimization complete.');
 
 function formatBytes(bytes) {


### PR DESCRIPTION
## Summary

- Add a CI step that reports the optimized WASM binary size to the GitHub Actions step summary after each build of the `wasm32-wasip1-threads` target
- Enhance `scripts/optimize-wasm.js` to report aggregate size totals when processing multiple WASM files
- Document WASM bundle size tracking in the README Platform Support section

## Related issue

Closes #52

## Checklist

- [x] CI reports WASM size on each build (step summary)
- [x] Optimization script reports clear before/after sizes with totals
- [x] WASM bundle size documented in README
- [x] All existing tests pass
- [x] Biome lint and cargo clippy pass