### PR TITLE
ci: migrate release workflow to npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: release-version
@@ -140,8 +142,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.settings.target }}
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:


### PR DESCRIPTION
## Summary

- Remove `NPM_TOKEN` / `NODE_AUTH_TOKEN` secret dependency from the publish job
- Rely on OIDC token exchange via `id-token: write` permission (already set)
- Simplify publish command to `npm publish --provenance --access public`

Closes #39

## Migration steps (manual, required before next release)

Trusted publishing must be configured on npmjs.com for **each** package:

1. Go to [npmjs.com](https://www.npmjs.com/) and sign in
2. For each package below, navigate to **Settings → Trusted publishers → Add GitHub Actions**:
   - `zflate`
   - `zflate-darwin-arm64`
   - `zflate-darwin-x64`
   - `zflate-linux-arm64-gnu`
   - `zflate-linux-arm64-musl`
   - `zflate-linux-x64-gnu`
   - `zflate-linux-x64-musl`
   - `zflate-wasm32-wasi`
   - `zflate-win32-arm64-msvc`
   - `zflate-win32-x64-msvc`
3. Configure each with:
   - **Repository**: `derodero24/zflate`
   - **Workflow**: `release.yml`
   - **Environment**: *(leave empty)*
4. After trusted publishing is verified working, remove the `NPM_TOKEN` secret from the repository settings

## Checklist

- [x] `id-token: write` permission already present
- [x] `setup-node` with `registry-url: https://registry.npmjs.org/` already present
- [x] `NPM_TOKEN` / `NODE_AUTH_TOKEN` env vars removed from publish step
- [x] `--provenance` flag retained for explicit provenance attestation
- [ ] Trusted publishing configured on npmjs.com for all packages (manual step)
- [ ] `NPM_TOKEN` secret removed from repository settings (after verification)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* **CI/CD ワークフローの改善**
  * ツールチェーン管理プロセスを最適化
  * パッケージ公開コマンドを簡素化
  * セキュアな認証メカニズムを導入してデプロイメント手順を強化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->