### PR TITLE
feat(api): accept Uint8Array input in all compression functions

### DIFF
--- a/crates/core/src/brotli_impl.rs
+++ b/crates/core/src/brotli_impl.rs
@@ -22,7 +22,7 @@ const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
 /// Returns the compressed data as a Buffer.
 /// Quality ranges from 0 (fastest) to 11 (best compression). Default is 6.
 #[napi]
-pub fn brotli_compress(data: Buffer, quality: Option<u32>) -> Result<Buffer> {
+pub fn brotli_compress(data: Either<Buffer, Uint8Array>, quality: Option<u32>) -> Result<Buffer> {
     let quality = quality.unwrap_or(DEFAULT_QUALITY);
     if quality > 11 {
         return Err(Error::new(
@@ -30,7 +30,7 @@ pub fn brotli_compress(data: Buffer, quality: Option<u32>) -> Result<Buffer> {
             "brotli quality must be between 0 and 11",
         ));
     }
-    let input = data.as_ref();
+    let input = crate::as_bytes(&data);
 
     let mut output = Vec::with_capacity(input.len());
     {
@@ -53,8 +53,8 @@ pub fn brotli_compress(data: Buffer, quality: Option<u32>) -> Result<Buffer> {
 /// Returns the decompressed data as a Buffer.
 /// The maximum decompressed size is 256 MB.
 #[napi]
-pub fn brotli_decompress(data: Buffer) -> Result<Buffer> {
-    let input = data.as_ref();
+pub fn brotli_decompress(data: Either<Buffer, Uint8Array>) -> Result<Buffer> {
+    let input = crate::as_bytes(&data);
     let mut decompressor = brotli::Decompressor::new(input, BUFFER_SIZE);
 
     let mut output = Vec::with_capacity(input.len().min(MAX_DECOMPRESSED_SIZE));
@@ -90,14 +90,17 @@ pub fn brotli_decompress(data: Buffer) -> Result<Buffer> {
 /// Use this when the decompressed size exceeds the default 256 MB limit.
 /// The `capacity` parameter specifies the maximum decompressed size in bytes.
 #[napi]
-pub fn brotli_decompress_with_capacity(data: Buffer, capacity: f64) -> Result<Buffer> {
+pub fn brotli_decompress_with_capacity(
+    data: Either<Buffer, Uint8Array>,
+    capacity: f64,
+) -> Result<Buffer> {
     if !capacity.is_finite() || capacity < 0.0 {
         return Err(Error::new(
             Status::InvalidArg,
             "capacity must be a positive finite number",
         ));
     }
-    let input = data.as_ref();
+    let input = crate::as_bytes(&data);
     let cap = capacity as usize;
 
     let mut decompressor = brotli::Decompressor::new(input, BUFFER_SIZE);

--- a/crates/core/src/brotli_stream.rs
+++ b/crates/core/src/brotli_stream.rs
@@ -42,13 +42,15 @@ impl BrotliCompressContext {
     /// Compress a chunk of data. Returns compressed output (may be empty if
     /// the compressor is buffering data internally).
     #[napi]
-    pub fn transform(&mut self, chunk: Buffer) -> Result<Buffer> {
-        self.compressor.write_all(chunk.as_ref()).map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("brotli stream compress failed: {e}"),
-            )
-        })?;
+    pub fn transform(&mut self, chunk: Either<Buffer, Uint8Array>) -> Result<Buffer> {
+        self.compressor
+            .write_all(crate::as_bytes(&chunk))
+            .map_err(|e| {
+                Error::new(
+                    Status::GenericFailure,
+                    format!("brotli stream compress failed: {e}"),
+                )
+            })?;
 
         // Drain whatever the compressor has flushed to the inner Vec
         let output = self.compressor.get_ref().clone();
@@ -108,13 +110,15 @@ impl BrotliDecompressContext {
     /// Decompress a chunk of compressed data. Returns decompressed output
     /// (may be empty if the decompressor needs more data).
     #[napi]
-    pub fn transform(&mut self, chunk: Buffer) -> Result<Buffer> {
-        self.decompressor.write_all(chunk.as_ref()).map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("brotli stream decompress failed: {e}"),
-            )
-        })?;
+    pub fn transform(&mut self, chunk: Either<Buffer, Uint8Array>) -> Result<Buffer> {
+        self.decompressor
+            .write_all(crate::as_bytes(&chunk))
+            .map_err(|e| {
+                Error::new(
+                    Status::GenericFailure,
+                    format!("brotli stream decompress failed: {e}"),
+                )
+            })?;
 
         // Drain whatever the decompressor has written to the inner Vec
         let output = self.decompressor.get_ref().clone();

--- a/crates/core/src/gzip.rs
+++ b/crates/core/src/gzip.rs
@@ -22,7 +22,7 @@ const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
 /// Returns the compressed data as a Buffer.
 /// Level ranges from 0 (no compression) to 9 (best compression). Default is 6.
 #[napi]
-pub fn gzip_compress(data: Buffer, level: Option<u32>) -> Result<Buffer> {
+pub fn gzip_compress(data: Either<Buffer, Uint8Array>, level: Option<u32>) -> Result<Buffer> {
     let level = level.unwrap_or(DEFAULT_LEVEL);
     if level > 9 {
         return Err(Error::new(
@@ -30,7 +30,7 @@ pub fn gzip_compress(data: Buffer, level: Option<u32>) -> Result<Buffer> {
             "gzip compression level must be between 0 and 9",
         ));
     }
-    let input = data.as_ref();
+    let input = crate::as_bytes(&data);
 
     let mut encoder = GzEncoder::new(Vec::new(), Compression::new(level));
     encoder
@@ -48,8 +48,8 @@ pub fn gzip_compress(data: Buffer, level: Option<u32>) -> Result<Buffer> {
 /// The maximum decompressed size is 256 MB. Use `gzipDecompressWithCapacity`
 /// for larger data.
 #[napi]
-pub fn gzip_decompress(data: Buffer) -> Result<Buffer> {
-    decompress_gzip_with_limit(data.as_ref(), MAX_DECOMPRESSED_SIZE)
+pub fn gzip_decompress(data: Either<Buffer, Uint8Array>) -> Result<Buffer> {
+    decompress_gzip_with_limit(crate::as_bytes(&data), MAX_DECOMPRESSED_SIZE)
 }
 
 /// Decompress gzip-compressed data with explicit capacity.
@@ -57,14 +57,17 @@ pub fn gzip_decompress(data: Buffer) -> Result<Buffer> {
 /// Use this when the decompressed size exceeds the default 256 MB limit.
 /// The `capacity` parameter specifies the maximum decompressed size in bytes.
 #[napi]
-pub fn gzip_decompress_with_capacity(data: Buffer, capacity: f64) -> Result<Buffer> {
+pub fn gzip_decompress_with_capacity(
+    data: Either<Buffer, Uint8Array>,
+    capacity: f64,
+) -> Result<Buffer> {
     if !capacity.is_finite() || capacity < 0.0 {
         return Err(Error::new(
             Status::InvalidArg,
             "capacity must be a positive finite number",
         ));
     }
-    decompress_gzip_with_limit(data.as_ref(), capacity as usize)
+    decompress_gzip_with_limit(crate::as_bytes(&data), capacity as usize)
 }
 
 fn decompress_gzip_with_limit(input: &[u8], max_size: usize) -> Result<Buffer> {
@@ -102,7 +105,7 @@ fn decompress_gzip_with_limit(input: &[u8], max_size: usize) -> Result<Buffer> {
 /// Returns the compressed data as a Buffer.
 /// Level ranges from 0 (no compression) to 9 (best compression). Default is 6.
 #[napi]
-pub fn deflate_compress(data: Buffer, level: Option<u32>) -> Result<Buffer> {
+pub fn deflate_compress(data: Either<Buffer, Uint8Array>, level: Option<u32>) -> Result<Buffer> {
     let level = level.unwrap_or(DEFAULT_LEVEL);
     if level > 9 {
         return Err(Error::new(
@@ -110,7 +113,7 @@ pub fn deflate_compress(data: Buffer, level: Option<u32>) -> Result<Buffer> {
             "deflate compression level must be between 0 and 9",
         ));
     }
-    let input = data.as_ref();
+    let input = crate::as_bytes(&data);
 
     let mut encoder = DeflateEncoder::new(Vec::new(), Compression::new(level));
     encoder.write_all(input).map_err(|e| {
@@ -133,8 +136,8 @@ pub fn deflate_compress(data: Buffer, level: Option<u32>) -> Result<Buffer> {
 /// The maximum decompressed size is 256 MB. Use `deflateDecompressWithCapacity`
 /// for larger data.
 #[napi]
-pub fn deflate_decompress(data: Buffer) -> Result<Buffer> {
-    decompress_deflate_with_limit(data.as_ref(), MAX_DECOMPRESSED_SIZE)
+pub fn deflate_decompress(data: Either<Buffer, Uint8Array>) -> Result<Buffer> {
+    decompress_deflate_with_limit(crate::as_bytes(&data), MAX_DECOMPRESSED_SIZE)
 }
 
 /// Decompress raw deflate-compressed data with explicit capacity.
@@ -142,14 +145,17 @@ pub fn deflate_decompress(data: Buffer) -> Result<Buffer> {
 /// Use this when the decompressed size exceeds the default 256 MB limit.
 /// The `capacity` parameter specifies the maximum decompressed size in bytes.
 #[napi]
-pub fn deflate_decompress_with_capacity(data: Buffer, capacity: f64) -> Result<Buffer> {
+pub fn deflate_decompress_with_capacity(
+    data: Either<Buffer, Uint8Array>,
+    capacity: f64,
+) -> Result<Buffer> {
     if !capacity.is_finite() || capacity < 0.0 {
         return Err(Error::new(
             Status::InvalidArg,
             "capacity must be a positive finite number",
         ));
     }
-    decompress_deflate_with_limit(data.as_ref(), capacity as usize)
+    decompress_deflate_with_limit(crate::as_bytes(&data), capacity as usize)
 }
 
 fn decompress_deflate_with_limit(input: &[u8], max_size: usize) -> Result<Buffer> {

--- a/crates/core/src/gzip_stream.rs
+++ b/crates/core/src/gzip_stream.rs
@@ -39,13 +39,13 @@ impl GzipCompressContext {
     /// Compress a chunk of data. Returns compressed output (may be empty if
     /// the encoder is buffering data internally).
     #[napi]
-    pub fn transform(&mut self, chunk: Buffer) -> Result<Buffer> {
+    pub fn transform(&mut self, chunk: Either<Buffer, Uint8Array>) -> Result<Buffer> {
         let encoder = self
             .encoder
             .as_mut()
             .ok_or_else(|| Error::new(Status::GenericFailure, "gzip stream already finished"))?;
 
-        encoder.write_all(chunk.as_ref()).map_err(|e| {
+        encoder.write_all(crate::as_bytes(&chunk)).map_err(|e| {
             Error::new(
                 Status::GenericFailure,
                 format!("gzip stream compress failed: {e}"),
@@ -117,13 +117,13 @@ impl GzipDecompressContext {
     /// Decompress a chunk of compressed data. Returns decompressed output
     /// (may be empty if the decoder needs more data).
     #[napi]
-    pub fn transform(&mut self, chunk: Buffer) -> Result<Buffer> {
+    pub fn transform(&mut self, chunk: Either<Buffer, Uint8Array>) -> Result<Buffer> {
         let decoder = self
             .decoder
             .as_mut()
             .ok_or_else(|| Error::new(Status::GenericFailure, "gzip stream already finished"))?;
 
-        let input = chunk.as_ref();
+        let input = crate::as_bytes(&chunk);
         let mut pos = 0;
         while pos < input.len() {
             let n = decoder.write(&input[pos..]).map_err(|e| {
@@ -210,13 +210,13 @@ impl DeflateCompressContext {
     /// Compress a chunk of data. Returns compressed output (may be empty if
     /// the encoder is buffering data internally).
     #[napi]
-    pub fn transform(&mut self, chunk: Buffer) -> Result<Buffer> {
+    pub fn transform(&mut self, chunk: Either<Buffer, Uint8Array>) -> Result<Buffer> {
         let encoder = self
             .encoder
             .as_mut()
             .ok_or_else(|| Error::new(Status::GenericFailure, "deflate stream already finished"))?;
 
-        encoder.write_all(chunk.as_ref()).map_err(|e| {
+        encoder.write_all(crate::as_bytes(&chunk)).map_err(|e| {
             Error::new(
                 Status::GenericFailure,
                 format!("deflate stream compress failed: {e}"),
@@ -288,13 +288,13 @@ impl DeflateDecompressContext {
     /// Decompress a chunk of compressed data. Returns decompressed output
     /// (may be empty if the decoder needs more data).
     #[napi]
-    pub fn transform(&mut self, chunk: Buffer) -> Result<Buffer> {
+    pub fn transform(&mut self, chunk: Either<Buffer, Uint8Array>) -> Result<Buffer> {
         let decoder = self
             .decoder
             .as_mut()
             .ok_or_else(|| Error::new(Status::GenericFailure, "deflate stream already finished"))?;
 
-        decoder.write_all(chunk.as_ref()).map_err(|e| {
+        decoder.write_all(crate::as_bytes(&chunk)).map_err(|e| {
             Error::new(
                 Status::GenericFailure,
                 format!("deflate stream decompress failed: {e}"),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,7 +7,16 @@ mod gzip_stream;
 mod zstd;
 mod zstd_stream;
 
+use napi::bindgen_prelude::*;
 use napi_derive::napi;
+
+/// Extract byte slice from Either<Buffer, Uint8Array>.
+fn as_bytes(data: &Either<Buffer, Uint8Array>) -> &[u8] {
+    match data {
+        Either::A(buf) => buf.as_ref(),
+        Either::B(arr) => arr.as_ref(),
+    }
+}
 
 pub use brotli_impl::*;
 pub use brotli_stream::*;

--- a/crates/core/src/zstd.rs
+++ b/crates/core/src/zstd.rs
@@ -16,9 +16,9 @@ const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
 /// Negative levels (e.g., -1 to -131072) enable fast mode, trading compression
 /// ratio for speed. Level 0 is equivalent to the default level (3).
 #[napi]
-pub fn zstd_compress(data: Buffer, level: Option<i32>) -> Result<Buffer> {
+pub fn zstd_compress(data: Either<Buffer, Uint8Array>, level: Option<i32>) -> Result<Buffer> {
     let level = level.unwrap_or(DEFAULT_LEVEL);
-    let input = data.as_ref();
+    let input = crate::as_bytes(&data);
 
     zstd::bulk::compress(input, level)
         .map(|v| v.into())
@@ -31,8 +31,8 @@ pub fn zstd_compress(data: Buffer, level: Option<i32>) -> Result<Buffer> {
 /// The maximum decompressed size is 256 MB. Use `zstdDecompressWithCapacity`
 /// for larger data.
 #[napi]
-pub fn zstd_decompress(data: Buffer) -> Result<Buffer> {
-    let input = data.as_ref();
+pub fn zstd_decompress(data: Either<Buffer, Uint8Array>) -> Result<Buffer> {
+    let input = crate::as_bytes(&data);
 
     // Try to read the frame content size from the header
     let capacity = match zstd::zstd_safe::get_frame_content_size(input) {
@@ -58,14 +58,17 @@ pub fn zstd_decompress(data: Buffer) -> Result<Buffer> {
 /// Use this when the decompressed size exceeds the default 256 MB limit.
 /// The `capacity` parameter specifies the maximum decompressed size in bytes.
 #[napi]
-pub fn zstd_decompress_with_capacity(data: Buffer, capacity: f64) -> Result<Buffer> {
+pub fn zstd_decompress_with_capacity(
+    data: Either<Buffer, Uint8Array>,
+    capacity: f64,
+) -> Result<Buffer> {
     if !capacity.is_finite() || capacity < 0.0 {
         return Err(Error::new(
             Status::InvalidArg,
             "capacity must be a positive finite number",
         ));
     }
-    let input = data.as_ref();
+    let input = crate::as_bytes(&data);
     let cap = capacity as usize;
 
     zstd::bulk::decompress(input, cap)

--- a/crates/core/src/zstd_stream.rs
+++ b/crates/core/src/zstd_stream.rs
@@ -35,8 +35,8 @@ impl ZstdCompressContext {
     /// Compress a chunk of data. Returns compressed output (may be empty if
     /// the encoder is buffering data internally).
     #[napi]
-    pub fn transform(&mut self, chunk: Buffer) -> Result<Buffer> {
-        let input = chunk.as_ref();
+    pub fn transform(&mut self, chunk: Either<Buffer, Uint8Array>) -> Result<Buffer> {
+        let input = crate::as_bytes(&chunk);
         let bound = zstd::zstd_safe::compress_bound(input.len());
         let mut output = vec![0u8; bound.max(INITIAL_BUF_SIZE)];
 
@@ -142,8 +142,8 @@ impl ZstdDecompressContext {
     /// Decompress a chunk of compressed data. Returns decompressed output
     /// (may be empty if the decoder needs more data).
     #[napi]
-    pub fn transform(&mut self, chunk: Buffer) -> Result<Buffer> {
-        let input = chunk.as_ref();
+    pub fn transform(&mut self, chunk: Either<Buffer, Uint8Array>) -> Result<Buffer> {
+        let input = crate::as_bytes(&chunk);
         // Decompressed output can be much larger than input
         let mut output = vec![0u8; input.len().max(INITIAL_BUF_SIZE)];
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ export declare class BrotliCompressContext {
    * Compress a chunk of data. Returns compressed output (may be empty if
    * the compressor is buffering data internally).
    */
-  transform(chunk: Buffer): Buffer
+  transform(chunk: Buffer | Uint8Array): Buffer
   /** Flush the compressor's internal buffer. Returns any buffered compressed data. */
   flush(): Buffer
   /**
@@ -34,7 +34,7 @@ export declare class BrotliDecompressContext {
    * Decompress a chunk of compressed data. Returns decompressed output
    * (may be empty if the decompressor needs more data).
    */
-  transform(chunk: Buffer): Buffer
+  transform(chunk: Buffer | Uint8Array): Buffer
   /** Flush the decompressor's internal buffer. Returns any buffered decompressed data. */
   flush(): Buffer
 }
@@ -51,7 +51,7 @@ export declare class DeflateCompressContext {
    * Compress a chunk of data. Returns compressed output (may be empty if
    * the encoder is buffering data internally).
    */
-  transform(chunk: Buffer): Buffer
+  transform(chunk: Buffer | Uint8Array): Buffer
   /** Flush the encoder's internal buffer. Returns any buffered compressed data. */
   flush(): Buffer
   /**
@@ -73,7 +73,7 @@ export declare class DeflateDecompressContext {
    * Decompress a chunk of compressed data. Returns decompressed output
    * (may be empty if the decoder needs more data).
    */
-  transform(chunk: Buffer): Buffer
+  transform(chunk: Buffer | Uint8Array): Buffer
   /** Flush the decoder's internal buffer. Returns any buffered decompressed data. */
   flush(): Buffer
   /**
@@ -95,7 +95,7 @@ export declare class GzipCompressContext {
    * Compress a chunk of data. Returns compressed output (may be empty if
    * the encoder is buffering data internally).
    */
-  transform(chunk: Buffer): Buffer
+  transform(chunk: Buffer | Uint8Array): Buffer
   /** Flush the encoder's internal buffer. Returns any buffered compressed data. */
   flush(): Buffer
   /**
@@ -117,7 +117,7 @@ export declare class GzipDecompressContext {
    * Decompress a chunk of compressed data. Returns decompressed output
    * (may be empty if the decoder needs more data).
    */
-  transform(chunk: Buffer): Buffer
+  transform(chunk: Buffer | Uint8Array): Buffer
   /** Flush the decoder's internal buffer. Returns any buffered decompressed data. */
   flush(): Buffer
   /**
@@ -139,7 +139,7 @@ export declare class ZstdCompressContext {
    * Compress a chunk of data. Returns compressed output (may be empty if
    * the encoder is buffering data internally).
    */
-  transform(chunk: Buffer): Buffer
+  transform(chunk: Buffer | Uint8Array): Buffer
   /** Flush the encoder's internal buffer. Returns any buffered compressed data. */
   flush(): Buffer
   /**
@@ -161,7 +161,7 @@ export declare class ZstdDecompressContext {
    * Decompress a chunk of compressed data. Returns decompressed output
    * (may be empty if the decoder needs more data).
    */
-  transform(chunk: Buffer): Buffer
+  transform(chunk: Buffer | Uint8Array): Buffer
   /** Flush the decoder's internal buffer. Returns any buffered decompressed data. */
   flush(): Buffer
 }
@@ -172,7 +172,7 @@ export declare class ZstdDecompressContext {
  * Returns the compressed data as a Buffer.
  * Quality ranges from 0 (fastest) to 11 (best compression). Default is 6.
  */
-export declare function brotliCompress(data: Buffer, quality?: number | undefined | null): Buffer
+export declare function brotliCompress(data: Buffer | Uint8Array, quality?: number | undefined | null): Buffer
 
 /**
  * Decompress Brotli-compressed data.
@@ -180,7 +180,7 @@ export declare function brotliCompress(data: Buffer, quality?: number | undefine
  * Returns the decompressed data as a Buffer.
  * The maximum decompressed size is 256 MB.
  */
-export declare function brotliDecompress(data: Buffer): Buffer
+export declare function brotliDecompress(data: Buffer | Uint8Array): Buffer
 
 /**
  * Decompress Brotli-compressed data with explicit capacity.
@@ -188,7 +188,7 @@ export declare function brotliDecompress(data: Buffer): Buffer
  * Use this when the decompressed size exceeds the default 256 MB limit.
  * The `capacity` parameter specifies the maximum decompressed size in bytes.
  */
-export declare function brotliDecompressWithCapacity(data: Buffer, capacity: number): Buffer
+export declare function brotliDecompressWithCapacity(data: Buffer | Uint8Array, capacity: number): Buffer
 
 /**
  * Compress data using raw deflate (no gzip header/trailer).
@@ -196,7 +196,7 @@ export declare function brotliDecompressWithCapacity(data: Buffer, capacity: num
  * Returns the compressed data as a Buffer.
  * Level ranges from 0 (no compression) to 9 (best compression). Default is 6.
  */
-export declare function deflateCompress(data: Buffer, level?: number | undefined | null): Buffer
+export declare function deflateCompress(data: Buffer | Uint8Array, level?: number | undefined | null): Buffer
 
 /**
  * Decompress raw deflate-compressed data.
@@ -205,7 +205,7 @@ export declare function deflateCompress(data: Buffer, level?: number | undefined
  * The maximum decompressed size is 256 MB. Use `deflateDecompressWithCapacity`
  * for larger data.
  */
-export declare function deflateDecompress(data: Buffer): Buffer
+export declare function deflateDecompress(data: Buffer | Uint8Array): Buffer
 
 /**
  * Decompress raw deflate-compressed data with explicit capacity.
@@ -213,7 +213,7 @@ export declare function deflateDecompress(data: Buffer): Buffer
  * Use this when the decompressed size exceeds the default 256 MB limit.
  * The `capacity` parameter specifies the maximum decompressed size in bytes.
  */
-export declare function deflateDecompressWithCapacity(data: Buffer, capacity: number): Buffer
+export declare function deflateDecompressWithCapacity(data: Buffer | Uint8Array, capacity: number): Buffer
 
 /**
  * Compress data using gzip.
@@ -221,7 +221,7 @@ export declare function deflateDecompressWithCapacity(data: Buffer, capacity: nu
  * Returns the compressed data as a Buffer.
  * Level ranges from 0 (no compression) to 9 (best compression). Default is 6.
  */
-export declare function gzipCompress(data: Buffer, level?: number | undefined | null): Buffer
+export declare function gzipCompress(data: Buffer | Uint8Array, level?: number | undefined | null): Buffer
 
 /**
  * Decompress gzip-compressed data.
@@ -230,7 +230,7 @@ export declare function gzipCompress(data: Buffer, level?: number | undefined | 
  * The maximum decompressed size is 256 MB. Use `gzipDecompressWithCapacity`
  * for larger data.
  */
-export declare function gzipDecompress(data: Buffer): Buffer
+export declare function gzipDecompress(data: Buffer | Uint8Array): Buffer
 
 /**
  * Decompress gzip-compressed data with explicit capacity.
@@ -238,7 +238,7 @@ export declare function gzipDecompress(data: Buffer): Buffer
  * Use this when the decompressed size exceeds the default 256 MB limit.
  * The `capacity` parameter specifies the maximum decompressed size in bytes.
  */
-export declare function gzipDecompressWithCapacity(data: Buffer, capacity: number): Buffer
+export declare function gzipDecompressWithCapacity(data: Buffer | Uint8Array, capacity: number): Buffer
 
 /** Returns the library version. */
 export declare function version(): string
@@ -251,7 +251,7 @@ export declare function version(): string
  * Negative levels (e.g., -1 to -131072) enable fast mode, trading compression
  * ratio for speed. Level 0 is equivalent to the default level (3).
  */
-export declare function zstdCompress(data: Buffer, level?: number | undefined | null): Buffer
+export declare function zstdCompress(data: Buffer | Uint8Array, level?: number | undefined | null): Buffer
 
 /**
  * Decompress Zstandard-compressed data.
@@ -260,7 +260,7 @@ export declare function zstdCompress(data: Buffer, level?: number | undefined | 
  * The maximum decompressed size is 256 MB. Use `zstdDecompressWithCapacity`
  * for larger data.
  */
-export declare function zstdDecompress(data: Buffer): Buffer
+export declare function zstdDecompress(data: Buffer | Uint8Array): Buffer
 
 /**
  * Decompress Zstandard-compressed data with explicit capacity.
@@ -268,4 +268,4 @@ export declare function zstdDecompress(data: Buffer): Buffer
  * Use this when the decompressed size exceeds the default 256 MB limit.
  * The `capacity` parameter specifies the maximum decompressed size in bytes.
  */
-export declare function zstdDecompressWithCapacity(data: Buffer, capacity: number): Buffer
+export declare function zstdDecompressWithCapacity(data: Buffer | Uint8Array, capacity: number): Buffer


### PR DESCRIPTION
## Summary

- Change all 18 input parameters from `Buffer` to `Either<Buffer, Uint8Array>` in Rust code
- napi-rs auto-generates `Buffer | Uint8Array` TypeScript types for all one-shot and streaming functions
- Add shared `as_bytes()` helper in `lib.rs` to reduce code duplication
- Return types remain `Buffer` — no breaking changes for existing usage
- Both `Buffer` and `Uint8Array` are properly validated at the N-API level

Closes #42

## Test plan

- [x] `cargo clippy` passes
- [x] `cargo test` passes (35 tests)
- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (145 tests)
- [x] Generated `index.d.ts` shows `Buffer | Uint8Array` for all input parameters
- [x] Existing `Buffer`-based tests continue to pass unchanged