### PR TITLE
test: add cargo-fuzz targets for decompression fuzzing

### DIFF
--- a/crates/core/fuzz/Cargo.toml
+++ b/crates/core/fuzz/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "zflate-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+zstd = { version = "0.13", default-features = false }
+flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
+brotli = "8"
+
+# Prevent this from interfering with workspace members
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_zstd_decompress"
+path = "fuzz_targets/fuzz_zstd_decompress.rs"
+doc = false
+
+[[bin]]
+name = "fuzz_gzip_decompress"
+path = "fuzz_targets/fuzz_gzip_decompress.rs"
+doc = false
+
+[[bin]]
+name = "fuzz_deflate_decompress"
+path = "fuzz_targets/fuzz_deflate_decompress.rs"
+doc = false
+
+[[bin]]
+name = "fuzz_brotli_decompress"
+path = "fuzz_targets/fuzz_brotli_decompress.rs"
+doc = false

--- a/crates/core/fuzz/fuzz_targets/fuzz_brotli_decompress.rs
+++ b/crates/core/fuzz/fuzz_targets/fuzz_brotli_decompress.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use std::io::Read;
+use brotli::Decompressor;
+
+fuzz_target!(|data: &[u8]| {
+    let mut decoder = Decompressor::new(data, 4096);
+    let mut output = Vec::new();
+    let _ = decoder.take(1024 * 1024).read_to_end(&mut output);
+});

--- a/crates/core/fuzz/fuzz_targets/fuzz_deflate_decompress.rs
+++ b/crates/core/fuzz/fuzz_targets/fuzz_deflate_decompress.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use std::io::Read;
+use flate2::read::DeflateDecoder;
+
+fuzz_target!(|data: &[u8]| {
+    let mut decoder = DeflateDecoder::new(data);
+    let mut output = Vec::new();
+    let _ = decoder.take(1024 * 1024).read_to_end(&mut output);
+});

--- a/crates/core/fuzz/fuzz_targets/fuzz_gzip_decompress.rs
+++ b/crates/core/fuzz/fuzz_targets/fuzz_gzip_decompress.rs
@@ -1,0 +1,11 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use std::io::Read;
+use flate2::read::GzDecoder;
+
+fuzz_target!(|data: &[u8]| {
+    let mut decoder = GzDecoder::new(data);
+    let mut output = Vec::new();
+    // Decompression of arbitrary data must never panic
+    let _ = decoder.take(1024 * 1024).read_to_end(&mut output);
+});

--- a/crates/core/fuzz/fuzz_targets/fuzz_zstd_decompress.rs
+++ b/crates/core/fuzz/fuzz_targets/fuzz_zstd_decompress.rs
@@ -1,0 +1,7 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // Decompression of arbitrary data must never panic
+    let _ = zstd::bulk::decompress(data, 1024 * 1024); // 1MB limit for fuzzing
+});


### PR DESCRIPTION
## Summary

- Add `cargo-fuzz` (libFuzzer) fuzz testing infrastructure at `crates/core/fuzz/`
- Add four fuzz targets for decompression functions: zstd, gzip, deflate, and brotli
- Each target feeds arbitrary data into the decompressor with a 1MB output limit, verifying that invalid inputs produce errors rather than panics or crashes
- The fuzz crate is standalone (not a workspace member) to avoid interfering with the main build

## How to run

Requires nightly Rust and `cargo-fuzz`:

```bash
cargo install cargo-fuzz

cd crates/core
cargo +nightly fuzz run fuzz_zstd_decompress
cargo +nightly fuzz run fuzz_gzip_decompress
cargo +nightly fuzz run fuzz_deflate_decompress
cargo +nightly fuzz run fuzz_brotli_decompress
```

Each target runs indefinitely until stopped with Ctrl+C or a crash is found.

## Checklist

- [x] Fuzz targets created for all four decompression algorithms
- [x] Fuzz crate is independent from the workspace
- [x] Existing `cargo test`, `cargo clippy`, `pnpm test`, and `pnpm run check` all pass

Closes #44