### PR TITLE
fix: add missing ESM exports for new functions

### DIFF
--- a/__test__/esm-import.mjs
+++ b/__test__/esm-import.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import {
   brotliCompress,
   brotliDecompress,
+  brotliDecompressWithCapacity,
   createBrotliCompressStream,
   createBrotliDecompressStream,
   createDeflateCompressStream,
@@ -10,13 +11,18 @@ import {
   createGzipDecompressStream,
   createZstdCompressStream,
   createZstdDecompressStream,
+  decompress,
   deflateCompress,
   deflateDecompress,
+  deflateDecompressWithCapacity,
+  detectFormat,
   gzipCompress,
   gzipDecompress,
+  gzipDecompressWithCapacity,
   version,
   zstdCompress,
   zstdDecompress,
+  zstdDecompressWithCapacity,
 } from '../index.mjs';
 
 assert.strictEqual(typeof version, 'function', 'version should be a function');
@@ -56,8 +62,30 @@ assert.strictEqual(
   'function',
   'createDeflateDecompressStream should be a function',
 );
+assert.strictEqual(typeof decompress, 'function', 'decompress should be a function');
+assert.strictEqual(typeof detectFormat, 'function', 'detectFormat should be a function');
 assert.strictEqual(typeof brotliCompress, 'function', 'brotliCompress should be a function');
 assert.strictEqual(typeof brotliDecompress, 'function', 'brotliDecompress should be a function');
+assert.strictEqual(
+  typeof brotliDecompressWithCapacity,
+  'function',
+  'brotliDecompressWithCapacity should be a function',
+);
+assert.strictEqual(
+  typeof zstdDecompressWithCapacity,
+  'function',
+  'zstdDecompressWithCapacity should be a function',
+);
+assert.strictEqual(
+  typeof gzipDecompressWithCapacity,
+  'function',
+  'gzipDecompressWithCapacity should be a function',
+);
+assert.strictEqual(
+  typeof deflateDecompressWithCapacity,
+  'function',
+  'deflateDecompressWithCapacity should be a function',
+);
 assert.strictEqual(
   typeof createBrotliCompressStream,
   'function',
@@ -89,5 +117,9 @@ assert.deepStrictEqual(dfDecompressed, input, 'deflate round-trip should produce
 const brCompressed = brotliCompress(input);
 const brDecompressed = brotliDecompress(brCompressed);
 assert.deepStrictEqual(brDecompressed, input, 'brotli round-trip should produce identical output');
+
+// Auto-detect decompression test
+const autoDecompressed = decompress(gzCompressed);
+assert.deepStrictEqual(autoDecompressed, input, 'decompress should auto-detect gzip');
 
 console.log('ESM import smoke test passed');

--- a/index.mjs
+++ b/index.mjs
@@ -6,6 +6,8 @@ const streams = require('./streams.js');
 
 export const {
   version,
+  decompress,
+  detectFormat,
   brotliCompress,
   brotliDecompress,
   brotliDecompressWithCapacity,
@@ -18,8 +20,10 @@ export const {
   ZstdDecompressContext,
   gzipCompress,
   gzipDecompress,
+  gzipDecompressWithCapacity,
   deflateCompress,
   deflateDecompress,
+  deflateDecompressWithCapacity,
   GzipCompressContext,
   GzipDecompressContext,
   DeflateCompressContext,


### PR DESCRIPTION
## Summary

- Add missing ESM exports in `index.mjs` for `decompress`, `detectFormat`, `gzipDecompressWithCapacity`, and `deflateDecompressWithCapacity`
- Update `__test__/esm-import.mjs` to verify all new exports are available and functional, including an auto-detect decompression round-trip test

These functions were already available via CJS `require('zflate')` and declared in `index.d.ts`, but were not re-exported from the ESM entry point (`index.mjs`).

## Related issue

Closes #73

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (230 tests)
- [x] `cargo test` passes (41 tests)
- [x] `cargo clippy` passes
- [x] `node __test__/esm-import.mjs` smoke test passes
- [x] `index.d.mts` already re-exports all types via `export * from './index.d.ts'`