### PR TITLE
fix(brotli): use consistent error message for capacity exceeded

### DIFF
--- a/__test__/brotli.spec.ts
+++ b/__test__/brotli.spec.ts
@@ -115,9 +115,7 @@ describe('brotliDecompressWithCapacity', () => {
   });
 
   it('should throw with insufficient capacity', () => {
-    expect(() => brotliDecompressWithCapacity(compressed, 1)).toThrow(
-      /Destination buffer is too small/,
-    );
+    expect(() => brotliDecompressWithCapacity(compressed, 1)).toThrow(/exceeded maximum size/);
   });
 
   it('should throw with negative capacity', () => {

--- a/crates/core/src/brotli_impl.rs
+++ b/crates/core/src/brotli_impl.rs
@@ -120,7 +120,7 @@ pub fn brotli_decompress_with_capacity(
         if output.len() + n > cap {
             return Err(Error::new(
                 Status::GenericFailure,
-                "Destination buffer is too small",
+                format!("brotli decompress exceeded maximum size of {} bytes", cap),
             ));
         }
         output.extend_from_slice(&buf[..n]);


### PR DESCRIPTION
## Summary

- Change `brotli_decompress_with_capacity` error message from `"Destination buffer is too small"` to `"brotli decompress exceeded maximum size of {} bytes"`
- Matches the error pattern used by all other decompress functions (gzip, deflate, brotli one-shot)
- Update test expectation accordingly

Closes #77

## Test plan

- [x] `cargo clippy` passes
- [x] `cargo test` passes (41 tests)
- [x] `pnpm run check` passes
- [x] `pnpm test` passes (265 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Brotli展開で提供された容量を超える場合、より詳細なエラーメッセージを表示するように改善しました。最大容量制限に関する具体的な情報がエラーに含まれるようになり、トラブルシューティングが容易になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->