### PR TITLE
ci: include Node.js WASM loader files in CI artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,9 @@ jobs:
           name: bindings-wasm32
           path: |
             *.wasm
+            *.wasi.cjs
             *.wasi-browser.js
+            wasi-worker.mjs
             wasi-worker-browser.mjs
           if-no-files-found: ignore
 


### PR DESCRIPTION
## Summary

- Add missing Node.js WASM loader files (`*.wasi.cjs`, `wasi-worker.mjs`) to the CI workflow's WASM artifact upload step
- The CI workflow was only uploading browser WASM loaders (`*.wasi-browser.js`, `wasi-worker-browser.mjs`), missing the Node.js equivalents needed for WASM testing in Node.js environments
- Aligns CI artifact upload patterns with the release workflow for consistency

## Related issue

Closes #85

## Checklist

- [x] CI workflow updated to include all WASM loader files
- [x] Patterns match release workflow artifact upload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ビルドプロセスのアーティファクト配布設定を拡張しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->