### PR TITLE
docs: remove Cloudflare Workers from supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The JavaScript compression ecosystem is fragmented across 12+ packages with inco
 - **Native performance** — Rust core compiled via napi-rs, with WASM fallback for browsers
 - **Unified API** — Same interface for zstd, gzip, and brotli
 - **Streaming** — Web Streams API (`TransformStream`) for processing large data with bounded memory
-- **Universal** — Node.js (native), browsers, Deno, Bun, and edge runtimes (WASM)
+- **Universal** — Node.js (native), browsers, Deno, and Bun (WASM)
 - **Zero JS dependencies** — Only Rust and the platform
 
 ## Installation
@@ -159,7 +159,6 @@ zstdCompress(data, -1);
 | Browsers | WASM | ✅ |
 | Deno | WASM | ✅ |
 | Bun | WASM | ✅ |
-| Cloudflare Workers | WASM | ✅ |
 
 ### Build targets
 


### PR DESCRIPTION
## Summary

- Remove Cloudflare Workers from the Platform Support table in README
- Remove "edge runtimes" from the "Why zflate?" feature list

Cloudflare Workers is not a viable platform for zflate because:

- **WASM target incompatibility**: napi-rs compiles to `wasm32-wasip1-threads`, which requires `SharedArrayBuffer` and multi-threading support. Cloudflare Workers runs in single-threaded V8 isolates that do not provide `SharedArrayBuffer`.
- **TransformStream limitation**: The Workers runtime `TransformStream` implementation only supports identity transforms (no custom `transform()` function), making zflate's streaming API unusable.

Closes #84