### PR TITLE
test(wasm): add Node.js WASM compatibility test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,31 @@ jobs:
       - name: ESM import smoke test
         run: node __test__/esm-import.mjs
 
+  test-wasm:
+    name: WASM Test (Node.js)
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Download native artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: bindings-x86_64-unknown-linux-gnu
+          path: .
+      - name: Download WASM artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: bindings-wasm32
+          path: .
+      - name: Run WASM tests
+        run: pnpm run test:wasm
+
   coverage:
     name: Coverage
     needs: [build]

--- a/__test__/wasm.spec.ts
+++ b/__test__/wasm.spec.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+// Check if WASM module is available (not built locally by default)
+let wasmAvailable = false;
+// biome-ignore lint/suspicious/noExplicitAny: WASM module loaded dynamically
+let wasm: any;
+try {
+  wasm = require('../zflate.wasi.cjs');
+  wasmAvailable = true;
+} catch {
+  // WASM binary not built — skip tests
+}
+
+describe.skipIf(!wasmAvailable)('WASM compatibility', () => {
+  describe('one-shot compression', () => {
+    const testData = Buffer.from('Hello, WASM zflate! '.repeat(100));
+
+    it('should round-trip with zstd', () => {
+      const compressed = wasm.zstdCompress(testData);
+      const decompressed = wasm.zstdDecompress(compressed);
+      expect(Buffer.from(decompressed)).toEqual(testData);
+    });
+
+    it('should round-trip with gzip', () => {
+      const compressed = wasm.gzipCompress(testData);
+      const decompressed = wasm.gzipDecompress(compressed);
+      expect(Buffer.from(decompressed)).toEqual(testData);
+    });
+
+    it('should round-trip with deflate', () => {
+      const compressed = wasm.deflateCompress(testData);
+      const decompressed = wasm.deflateDecompress(compressed);
+      expect(Buffer.from(decompressed)).toEqual(testData);
+    });
+
+    it('should round-trip with brotli', () => {
+      const compressed = wasm.brotliCompress(testData);
+      const decompressed = wasm.brotliDecompress(compressed);
+      expect(Buffer.from(decompressed)).toEqual(testData);
+    });
+  });
+
+  describe('auto-detect decompression', () => {
+    const testData = Buffer.from('Auto-detect test data '.repeat(50));
+
+    it('should auto-detect zstd', () => {
+      const compressed = wasm.zstdCompress(testData);
+      expect(wasm.detectFormat(compressed)).toBe('zstd');
+      const decompressed = wasm.decompress(compressed);
+      expect(Buffer.from(decompressed)).toEqual(testData);
+    });
+
+    it('should auto-detect gzip', () => {
+      const compressed = wasm.gzipCompress(testData);
+      expect(wasm.detectFormat(compressed)).toBe('gzip');
+      const decompressed = wasm.decompress(compressed);
+      expect(Buffer.from(decompressed)).toEqual(testData);
+    });
+
+    it('should auto-detect brotli via decompress', () => {
+      // Brotli has no magic bytes, detectFormat may return 'unknown'
+      // but decompress() should still try brotli as fallback
+      const compressed = wasm.brotliCompress(testData);
+      const decompressed = wasm.decompress(compressed);
+      expect(Buffer.from(decompressed)).toEqual(testData);
+    });
+  });
+
+  describe('version', () => {
+    it('should return version string', () => {
+      const ver = wasm.version();
+      expect(typeof ver).toBe('string');
+      expect(ver).toMatch(/^\d+\.\d+\.\d+/);
+    });
+  });
+
+  describe('native parity', () => {
+    // Import native bindings for comparison
+    // These are available because tests run after `pnpm run build`
+    const native = require('../index.js');
+    const testData = Buffer.from('Native parity verification data '.repeat(100));
+
+    it('zstd: WASM output should match native output', () => {
+      const wasmCompressed = wasm.zstdCompress(testData);
+      const nativeCompressed = native.zstdCompress(testData);
+      expect(Buffer.from(wasmCompressed)).toEqual(Buffer.from(nativeCompressed));
+    });
+
+    it('gzip: WASM decompression should match native decompression', () => {
+      // Gzip includes timestamps, so compressed output may differ.
+      // Instead, verify cross-decompression works.
+      const nativeCompressed = native.gzipCompress(testData);
+      const wasmDecompressed = wasm.gzipDecompress(nativeCompressed);
+      expect(Buffer.from(wasmDecompressed)).toEqual(testData);
+
+      const wasmCompressed = wasm.gzipCompress(testData);
+      const nativeDecompressed = native.gzipDecompress(wasmCompressed);
+      expect(Buffer.from(nativeDecompressed)).toEqual(testData);
+    });
+
+    it('deflate: WASM output should match native output', () => {
+      const wasmCompressed = wasm.deflateCompress(testData);
+      const nativeCompressed = native.deflateCompress(testData);
+      expect(Buffer.from(wasmCompressed)).toEqual(Buffer.from(nativeCompressed));
+    });
+
+    it('brotli: WASM decompression should match native decompression', () => {
+      const nativeCompressed = native.brotliCompress(testData);
+      const wasmDecompressed = wasm.brotliDecompress(nativeCompressed);
+      expect(Buffer.from(wasmDecompressed)).toEqual(testData);
+
+      const wasmCompressed = wasm.brotliCompress(testData);
+      const nativeDecompressed = native.brotliDecompress(wasmCompressed);
+      expect(Buffer.from(nativeDecompressed)).toEqual(testData);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "lint:fix": "biome check --write",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:wasm": "vitest run __test__/wasm.spec.ts",
     "test:watch": "vitest watch",
     "bench": "vitest bench",
     "attw": "attw --pack .",


### PR DESCRIPTION
## Summary

- Add `__test__/wasm.spec.ts` with WASM compatibility tests covering one-shot compression (zstd, gzip, deflate, brotli), auto-detect decompression, version check, and native parity verification
- Add `test:wasm` npm script to run WASM tests independently
- Add `test-wasm` CI job that downloads both native and WASM build artifacts to validate WASM behavior in Node.js

Tests are wrapped in `describe.skipIf(!wasmAvailable)` so they gracefully skip when the WASM binary is not present (local dev), and only run in CI where the WASM artifact is available.

Native parity tests use cross-decompression for gzip and brotli (non-deterministic compressed output) and byte-identical comparison for zstd and deflate (deterministic).

Closes #86

## Test plan

- [x] `pnpm run check` — Biome lint passes
- [x] `pnpm run typecheck` — TypeScript type check passes
- [x] `pnpm test` — All existing tests pass; WASM tests correctly skipped locally (no WASM binary)
- [x] `cargo test` — Rust tests pass
- [x] `cargo clippy` — No warnings
- [ ] CI `test-wasm` job passes with downloaded WASM + native artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * WebAssembly互換性テストスイートを追加

* **保守**
  * 継続的統合パイプラインにWebAssembly自動検証ジョブを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->