### PR TITLE
refactor(core): introduce thiserror for structured error types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +477,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "thiserror",
  "zstd",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ brotli = { version = "8", default-features = false, features = ["std"] }
 zstd = { version = "0.13", default-features = false, features = ["zdict_builder"] }
 flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
 
+# Error handling
+thiserror = "2"
+
 [profile.release]
 codegen-units = 1
 lto = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -14,6 +14,7 @@ napi = { workspace = true }
 napi-derive = { workspace = true }
 zstd = { workspace = true }
 flate2 = { workspace = true }
+thiserror = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }

--- a/crates/core/src/brotli_impl.rs
+++ b/crates/core/src/brotli_impl.rs
@@ -6,6 +6,8 @@ use napi::Task;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
+use crate::ZflateError;
+
 /// Default compression quality for brotli.
 const DEFAULT_QUALITY: u32 = 6;
 
@@ -26,10 +28,9 @@ const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
 pub fn brotli_compress(data: Either<Buffer, Uint8Array>, quality: Option<u32>) -> Result<Buffer> {
     let quality = quality.unwrap_or(DEFAULT_QUALITY);
     if quality > 11 {
-        return Err(Error::new(
-            Status::InvalidArg,
-            "brotli quality must be between 0 and 11",
-        ));
+        return Err(
+            ZflateError::InvalidArg("brotli quality must be between 0 and 11".to_string()).into(),
+        );
     }
     let input = crate::as_bytes(&data);
 
@@ -38,10 +39,10 @@ pub fn brotli_compress(data: Either<Buffer, Uint8Array>, quality: Option<u32>) -
         let mut compressor =
             brotli::CompressorWriter::new(&mut output, BUFFER_SIZE, quality, LG_WINDOW_SIZE);
         compressor.write_all(input).map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("brotli compress failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "brotli compress",
+                source: e.into(),
+            })
         })?;
         // Drop compressor to flush and finalize
     }
@@ -63,22 +64,20 @@ pub fn brotli_decompress(data: Either<Buffer, Uint8Array>) -> Result<Buffer> {
 
     loop {
         let n = decompressor.read(&mut buf).map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("brotli decompress failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "brotli decompress",
+                source: e.into(),
+            })
         })?;
         if n == 0 {
             break;
         }
         if output.len() + n > MAX_DECOMPRESSED_SIZE {
-            return Err(Error::new(
-                Status::GenericFailure,
-                format!(
-                    "brotli decompress exceeded maximum size of {} bytes",
-                    MAX_DECOMPRESSED_SIZE
-                ),
-            ));
+            return Err(ZflateError::SizeLimit {
+                context: "brotli decompress",
+                limit: MAX_DECOMPRESSED_SIZE,
+            }
+            .into());
         }
         output.extend_from_slice(&buf[..n]);
     }
@@ -96,10 +95,10 @@ pub fn brotli_decompress_with_capacity(
     capacity: f64,
 ) -> Result<Buffer> {
     if !capacity.is_finite() || capacity < 0.0 {
-        return Err(Error::new(
-            Status::InvalidArg,
-            "capacity must be a positive finite number",
-        ));
+        return Err(ZflateError::InvalidArg(
+            "capacity must be a positive finite number".to_string(),
+        )
+        .into());
     }
     let input = crate::as_bytes(&data);
     let cap = capacity as usize;
@@ -110,19 +109,20 @@ pub fn brotli_decompress_with_capacity(
 
     loop {
         let n = decompressor.read(&mut buf).map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("brotli decompress failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "brotli decompress",
+                source: e.into(),
+            })
         })?;
         if n == 0 {
             break;
         }
         if output.len() + n > cap {
-            return Err(Error::new(
-                Status::GenericFailure,
-                format!("brotli decompress exceeded maximum size of {} bytes", cap),
-            ));
+            return Err(ZflateError::SizeLimit {
+                context: "brotli decompress",
+                limit: cap,
+            }
+            .into());
         }
         output.extend_from_slice(&buf[..n]);
     }
@@ -152,10 +152,10 @@ impl Task for BrotliCompressTask {
                 LG_WINDOW_SIZE,
             );
             compressor.write_all(&self.data).map_err(|e| {
-                Error::new(
-                    Status::GenericFailure,
-                    format!("brotli compress failed: {e}"),
-                )
+                napi::Error::from(ZflateError::Operation {
+                    context: "brotli compress",
+                    source: e.into(),
+                })
             })?;
             // Drop compressor to flush and finalize
         }
@@ -178,10 +178,9 @@ pub fn brotli_compress_async(
 ) -> Result<AsyncTask<BrotliCompressTask>> {
     let quality = quality.unwrap_or(DEFAULT_QUALITY);
     if quality > 11 {
-        return Err(Error::new(
-            Status::InvalidArg,
-            "brotli quality must be between 0 and 11",
-        ));
+        return Err(
+            ZflateError::InvalidArg("brotli quality must be between 0 and 11".to_string()).into(),
+        );
     }
     let input = crate::as_bytes(&data).to_vec();
     Ok(AsyncTask::new(BrotliCompressTask {
@@ -206,22 +205,20 @@ impl Task for BrotliDecompressTask {
 
         loop {
             let n = decompressor.read(&mut buf).map_err(|e| {
-                Error::new(
-                    Status::GenericFailure,
-                    format!("brotli decompress failed: {e}"),
-                )
+                napi::Error::from(ZflateError::Operation {
+                    context: "brotli decompress",
+                    source: e.into(),
+                })
             })?;
             if n == 0 {
                 break;
             }
             if output.len() + n > MAX_DECOMPRESSED_SIZE {
-                return Err(Error::new(
-                    Status::GenericFailure,
-                    format!(
-                        "brotli decompress exceeded maximum size of {} bytes",
-                        MAX_DECOMPRESSED_SIZE
-                    ),
-                ));
+                return Err(ZflateError::SizeLimit {
+                    context: "brotli decompress",
+                    limit: MAX_DECOMPRESSED_SIZE,
+                }
+                .into());
             }
             output.extend_from_slice(&buf[..n]);
         }

--- a/crates/core/src/brotli_stream.rs
+++ b/crates/core/src/brotli_stream.rs
@@ -5,6 +5,8 @@ use std::io::Write;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
+use crate::ZflateError;
+
 /// Default compression quality for brotli.
 const DEFAULT_QUALITY: u32 = 6;
 
@@ -29,10 +31,10 @@ impl BrotliCompressContext {
     pub fn new(quality: Option<u32>) -> Result<Self> {
         let quality = quality.unwrap_or(DEFAULT_QUALITY);
         if quality > 11 {
-            return Err(Error::new(
-                Status::InvalidArg,
-                "brotli quality must be between 0 and 11",
-            ));
+            return Err(ZflateError::InvalidArg(
+                "brotli quality must be between 0 and 11".to_string(),
+            )
+            .into());
         }
         let compressor =
             brotli::CompressorWriter::new(Vec::new(), BUFFER_SIZE, quality, LG_WINDOW_SIZE);
@@ -46,10 +48,10 @@ impl BrotliCompressContext {
         self.compressor
             .write_all(crate::as_bytes(&chunk))
             .map_err(|e| {
-                Error::new(
-                    Status::GenericFailure,
-                    format!("brotli stream compress failed: {e}"),
-                )
+                napi::Error::from(ZflateError::Operation {
+                    context: "brotli stream compress",
+                    source: e.into(),
+                })
             })?;
 
         // Drain whatever the compressor has flushed to the inner Vec
@@ -62,10 +64,10 @@ impl BrotliCompressContext {
     #[napi]
     pub fn flush(&mut self) -> Result<Buffer> {
         self.compressor.flush().map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("brotli stream flush failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "brotli stream flush",
+                source: e.into(),
+            })
         })?;
 
         let output = self.compressor.get_ref().clone();
@@ -114,10 +116,10 @@ impl BrotliDecompressContext {
         self.decompressor
             .write_all(crate::as_bytes(&chunk))
             .map_err(|e| {
-                Error::new(
-                    Status::GenericFailure,
-                    format!("brotli stream decompress failed: {e}"),
-                )
+                napi::Error::from(ZflateError::Operation {
+                    context: "brotli stream decompress",
+                    source: e.into(),
+                })
             })?;
 
         // Drain whatever the decompressor has written to the inner Vec
@@ -130,10 +132,10 @@ impl BrotliDecompressContext {
     #[napi]
     pub fn flush(&mut self) -> Result<Buffer> {
         self.decompressor.flush().map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("brotli stream flush failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "brotli stream flush",
+                source: e.into(),
+            })
         })?;
 
         let output = self.decompressor.get_ref().clone();

--- a/crates/core/src/detect.rs
+++ b/crates/core/src/detect.rs
@@ -5,6 +5,8 @@
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
+use crate::ZflateError;
+
 /// Zstd magic number: 0xFD2FB528 (little-endian).
 const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
 
@@ -41,10 +43,10 @@ pub fn decompress(data: Either<Buffer, Uint8Array>) -> Result<Buffer> {
         Format::Zstd => crate::zstd_decompress(data),
         Format::Gzip => crate::gzip_decompress(data),
         Format::Brotli => crate::brotli_decompress(data),
-        Format::Unknown => Err(Error::new(
-            Status::InvalidArg,
-            "unable to detect compression format; use algorithm-specific functions (zstdDecompress, gzipDecompress, brotliDecompress) instead",
-        )),
+        Format::Unknown => Err(ZflateError::InvalidArg(
+            "unable to detect compression format; use algorithm-specific functions (zstdDecompress, gzipDecompress, brotliDecompress) instead".to_string(),
+        )
+        .into()),
     }
 }
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1,0 +1,45 @@
+//! Structured error types for zflate.
+
+use napi::bindgen_prelude::*;
+use thiserror::Error;
+
+/// Errors produced by zflate compression and decompression operations.
+#[derive(Error, Debug)]
+pub enum ZflateError {
+    /// Compression or decompression operation failure.
+    #[error("{context} failed: {source}")]
+    Operation {
+        context: &'static str,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// Resource creation failure (e.g. encoder/decoder initialization).
+    #[error("failed to create {context}: {source}")]
+    Creation {
+        context: &'static str,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// Invalid argument.
+    #[error("{0}")]
+    InvalidArg(String),
+
+    /// Decompressed output exceeded maximum size.
+    #[error("{context} exceeded maximum size of {limit} bytes")]
+    SizeLimit { context: &'static str, limit: usize },
+
+    /// Stream context has already been finalized.
+    #[error("{0} already finished")]
+    StreamFinished(&'static str),
+}
+
+impl From<ZflateError> for napi::Error {
+    fn from(e: ZflateError) -> Self {
+        match &e {
+            ZflateError::InvalidArg(_) => Error::new(Status::InvalidArg, e.to_string()),
+            _ => Error::new(Status::GenericFailure, e.to_string()),
+        }
+    }
+}

--- a/crates/core/src/gzip.rs
+++ b/crates/core/src/gzip.rs
@@ -9,6 +9,8 @@ use napi::Task;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
+use crate::ZflateError;
+
 /// Default compression level for gzip/deflate (flate2 default = 6).
 const DEFAULT_LEVEL: u32 = 6;
 
@@ -26,21 +28,26 @@ const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
 pub fn gzip_compress(data: Either<Buffer, Uint8Array>, level: Option<u32>) -> Result<Buffer> {
     let level = level.unwrap_or(DEFAULT_LEVEL);
     if level > 9 {
-        return Err(Error::new(
-            Status::InvalidArg,
-            "gzip compression level must be between 0 and 9",
-        ));
+        return Err(ZflateError::InvalidArg(
+            "gzip compression level must be between 0 and 9".to_string(),
+        )
+        .into());
     }
     let input = crate::as_bytes(&data);
 
     let mut encoder = GzEncoder::new(Vec::new(), Compression::new(level));
-    encoder
-        .write_all(input)
-        .map_err(|e| Error::new(Status::GenericFailure, format!("gzip compress failed: {e}")))?;
-    encoder
-        .finish()
-        .map(|v| v.into())
-        .map_err(|e| Error::new(Status::GenericFailure, format!("gzip compress failed: {e}")))
+    encoder.write_all(input).map_err(|e| {
+        napi::Error::from(ZflateError::Operation {
+            context: "gzip compress",
+            source: e.into(),
+        })
+    })?;
+    encoder.finish().map(|v| v.into()).map_err(|e| {
+        napi::Error::from(ZflateError::Operation {
+            context: "gzip compress",
+            source: e.into(),
+        })
+    })
 }
 
 /// Decompress gzip-compressed data.
@@ -63,10 +70,10 @@ pub fn gzip_decompress_with_capacity(
     capacity: f64,
 ) -> Result<Buffer> {
     if !capacity.is_finite() || capacity < 0.0 {
-        return Err(Error::new(
-            Status::InvalidArg,
-            "capacity must be a positive finite number",
-        ));
+        return Err(ZflateError::InvalidArg(
+            "capacity must be a positive finite number".to_string(),
+        )
+        .into());
     }
     decompress_gzip_with_limit(crate::as_bytes(&data), capacity as usize)
 }
@@ -78,22 +85,20 @@ fn decompress_gzip_with_limit(input: &[u8], max_size: usize) -> Result<Buffer> {
 
     loop {
         let n = decoder.read(&mut buf).map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("gzip decompress failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "gzip decompress",
+                source: e.into(),
+            })
         })?;
         if n == 0 {
             break;
         }
         if output.len() + n > max_size {
-            return Err(Error::new(
-                Status::GenericFailure,
-                format!(
-                    "gzip decompress exceeded maximum size of {} bytes",
-                    max_size
-                ),
-            ));
+            return Err(ZflateError::SizeLimit {
+                context: "gzip decompress",
+                limit: max_size,
+            }
+            .into());
         }
         output.extend_from_slice(&buf[..n]);
     }
@@ -109,25 +114,25 @@ fn decompress_gzip_with_limit(input: &[u8], max_size: usize) -> Result<Buffer> {
 pub fn deflate_compress(data: Either<Buffer, Uint8Array>, level: Option<u32>) -> Result<Buffer> {
     let level = level.unwrap_or(DEFAULT_LEVEL);
     if level > 9 {
-        return Err(Error::new(
-            Status::InvalidArg,
-            "deflate compression level must be between 0 and 9",
-        ));
+        return Err(ZflateError::InvalidArg(
+            "deflate compression level must be between 0 and 9".to_string(),
+        )
+        .into());
     }
     let input = crate::as_bytes(&data);
 
     let mut encoder = DeflateEncoder::new(Vec::new(), Compression::new(level));
     encoder.write_all(input).map_err(|e| {
-        Error::new(
-            Status::GenericFailure,
-            format!("deflate compress failed: {e}"),
-        )
+        napi::Error::from(ZflateError::Operation {
+            context: "deflate compress",
+            source: e.into(),
+        })
     })?;
     encoder.finish().map(|v| v.into()).map_err(|e| {
-        Error::new(
-            Status::GenericFailure,
-            format!("deflate compress failed: {e}"),
-        )
+        napi::Error::from(ZflateError::Operation {
+            context: "deflate compress",
+            source: e.into(),
+        })
     })
 }
 
@@ -151,10 +156,10 @@ pub fn deflate_decompress_with_capacity(
     capacity: f64,
 ) -> Result<Buffer> {
     if !capacity.is_finite() || capacity < 0.0 {
-        return Err(Error::new(
-            Status::InvalidArg,
-            "capacity must be a positive finite number",
-        ));
+        return Err(ZflateError::InvalidArg(
+            "capacity must be a positive finite number".to_string(),
+        )
+        .into());
     }
     decompress_deflate_with_limit(crate::as_bytes(&data), capacity as usize)
 }
@@ -166,22 +171,20 @@ fn decompress_deflate_with_limit(input: &[u8], max_size: usize) -> Result<Buffer
 
     loop {
         let n = decoder.read(&mut buf).map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("deflate decompress failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "deflate decompress",
+                source: e.into(),
+            })
         })?;
         if n == 0 {
             break;
         }
         if output.len() + n > max_size {
-            return Err(Error::new(
-                Status::GenericFailure,
-                format!(
-                    "deflate decompress exceeded maximum size of {} bytes",
-                    max_size
-                ),
-            ));
+            return Err(ZflateError::SizeLimit {
+                context: "deflate decompress",
+                limit: max_size,
+            }
+            .into());
         }
         output.extend_from_slice(&buf[..n]);
     }
@@ -204,11 +207,17 @@ impl Task for GzipCompressTask {
     fn compute(&mut self) -> Result<Self::Output> {
         let mut encoder = GzEncoder::new(Vec::new(), Compression::new(self.level));
         encoder.write_all(&self.data).map_err(|e| {
-            Error::new(Status::GenericFailure, format!("gzip compress failed: {e}"))
+            napi::Error::from(ZflateError::Operation {
+                context: "gzip compress",
+                source: e.into(),
+            })
         })?;
-        encoder
-            .finish()
-            .map_err(|e| Error::new(Status::GenericFailure, format!("gzip compress failed: {e}")))
+        encoder.finish().map_err(|e| {
+            napi::Error::from(ZflateError::Operation {
+                context: "gzip compress",
+                source: e.into(),
+            })
+        })
     }
 
     fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
@@ -227,10 +236,10 @@ pub fn gzip_compress_async(
 ) -> Result<AsyncTask<GzipCompressTask>> {
     let level = level.unwrap_or(DEFAULT_LEVEL);
     if level > 9 {
-        return Err(Error::new(
-            Status::InvalidArg,
-            "gzip compression level must be between 0 and 9",
-        ));
+        return Err(ZflateError::InvalidArg(
+            "gzip compression level must be between 0 and 9".to_string(),
+        )
+        .into());
     }
     let input = crate::as_bytes(&data).to_vec();
     Ok(AsyncTask::new(GzipCompressTask { data: input, level }))
@@ -252,22 +261,20 @@ impl Task for GzipDecompressTask {
 
         loop {
             let n = decoder.read(&mut buf).map_err(|e| {
-                Error::new(
-                    Status::GenericFailure,
-                    format!("gzip decompress failed: {e}"),
-                )
+                napi::Error::from(ZflateError::Operation {
+                    context: "gzip decompress",
+                    source: e.into(),
+                })
             })?;
             if n == 0 {
                 break;
             }
             if output.len() + n > MAX_DECOMPRESSED_SIZE {
-                return Err(Error::new(
-                    Status::GenericFailure,
-                    format!(
-                        "gzip decompress exceeded maximum size of {} bytes",
-                        MAX_DECOMPRESSED_SIZE
-                    ),
-                ));
+                return Err(ZflateError::SizeLimit {
+                    context: "gzip decompress",
+                    limit: MAX_DECOMPRESSED_SIZE,
+                }
+                .into());
             }
             output.extend_from_slice(&buf[..n]);
         }
@@ -304,16 +311,16 @@ impl Task for DeflateCompressTask {
     fn compute(&mut self) -> Result<Self::Output> {
         let mut encoder = DeflateEncoder::new(Vec::new(), Compression::new(self.level));
         encoder.write_all(&self.data).map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("deflate compress failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "deflate compress",
+                source: e.into(),
+            })
         })?;
         encoder.finish().map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("deflate compress failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "deflate compress",
+                source: e.into(),
+            })
         })
     }
 
@@ -333,10 +340,10 @@ pub fn deflate_compress_async(
 ) -> Result<AsyncTask<DeflateCompressTask>> {
     let level = level.unwrap_or(DEFAULT_LEVEL);
     if level > 9 {
-        return Err(Error::new(
-            Status::InvalidArg,
-            "deflate compression level must be between 0 and 9",
-        ));
+        return Err(ZflateError::InvalidArg(
+            "deflate compression level must be between 0 and 9".to_string(),
+        )
+        .into());
     }
     let input = crate::as_bytes(&data).to_vec();
     Ok(AsyncTask::new(DeflateCompressTask { data: input, level }))
@@ -358,22 +365,20 @@ impl Task for DeflateDecompressTask {
 
         loop {
             let n = decoder.read(&mut buf).map_err(|e| {
-                Error::new(
-                    Status::GenericFailure,
-                    format!("deflate decompress failed: {e}"),
-                )
+                napi::Error::from(ZflateError::Operation {
+                    context: "deflate decompress",
+                    source: e.into(),
+                })
             })?;
             if n == 0 {
                 break;
             }
             if output.len() + n > MAX_DECOMPRESSED_SIZE {
-                return Err(Error::new(
-                    Status::GenericFailure,
-                    format!(
-                        "deflate decompress exceeded maximum size of {} bytes",
-                        MAX_DECOMPRESSED_SIZE
-                    ),
-                ));
+                return Err(ZflateError::SizeLimit {
+                    context: "deflate decompress",
+                    limit: MAX_DECOMPRESSED_SIZE,
+                }
+                .into());
             }
             output.extend_from_slice(&buf[..n]);
         }

--- a/crates/core/src/gzip_stream.rs
+++ b/crates/core/src/gzip_stream.rs
@@ -7,6 +7,8 @@ use flate2::write::{DeflateDecoder, DeflateEncoder, GzDecoder, GzEncoder};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
+use crate::ZflateError;
+
 /// Default compression level for gzip/deflate (same as zlib default).
 const DEFAULT_LEVEL: u32 = 6;
 
@@ -25,10 +27,10 @@ impl GzipCompressContext {
     pub fn new(level: Option<u32>) -> Result<Self> {
         let level = level.unwrap_or(DEFAULT_LEVEL);
         if level > 9 {
-            return Err(Error::new(
-                Status::InvalidArg,
-                "gzip compression level must be between 0 and 9",
-            ));
+            return Err(ZflateError::InvalidArg(
+                "gzip compression level must be between 0 and 9".to_string(),
+            )
+            .into());
         }
         let encoder = GzEncoder::new(Vec::new(), Compression::new(level));
         Ok(Self {
@@ -43,13 +45,13 @@ impl GzipCompressContext {
         let encoder = self
             .encoder
             .as_mut()
-            .ok_or_else(|| Error::new(Status::GenericFailure, "gzip stream already finished"))?;
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("gzip stream")))?;
 
         encoder.write_all(crate::as_bytes(&chunk)).map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("gzip stream compress failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "gzip stream compress",
+                source: e.into(),
+            })
         })?;
 
         let output = encoder.get_mut();
@@ -63,13 +65,13 @@ impl GzipCompressContext {
         let encoder = self
             .encoder
             .as_mut()
-            .ok_or_else(|| Error::new(Status::GenericFailure, "gzip stream already finished"))?;
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("gzip stream")))?;
 
         encoder.flush().map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("gzip stream flush failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "gzip stream flush",
+                source: e.into(),
+            })
         })?;
 
         let output = encoder.get_mut();
@@ -84,13 +86,13 @@ impl GzipCompressContext {
         let encoder = self
             .encoder
             .take()
-            .ok_or_else(|| Error::new(Status::GenericFailure, "gzip stream already finished"))?;
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("gzip stream")))?;
 
         encoder.finish().map(|v| v.into()).map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("gzip stream finish failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "gzip stream finish",
+                source: e.into(),
+            })
         })
     }
 }
@@ -121,16 +123,16 @@ impl GzipDecompressContext {
         let decoder = self
             .decoder
             .as_mut()
-            .ok_or_else(|| Error::new(Status::GenericFailure, "gzip stream already finished"))?;
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("gzip stream")))?;
 
         let input = crate::as_bytes(&chunk);
         let mut pos = 0;
         while pos < input.len() {
             let n = decoder.write(&input[pos..]).map_err(|e| {
-                Error::new(
-                    Status::GenericFailure,
-                    format!("gzip stream decompress failed: {e}"),
-                )
+                napi::Error::from(ZflateError::Operation {
+                    context: "gzip stream decompress",
+                    source: e.into(),
+                })
             })?;
             if n == 0 {
                 break;
@@ -149,13 +151,13 @@ impl GzipDecompressContext {
         let decoder = self
             .decoder
             .as_mut()
-            .ok_or_else(|| Error::new(Status::GenericFailure, "gzip stream already finished"))?;
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("gzip stream")))?;
 
         decoder.flush().map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("gzip stream flush failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "gzip stream flush",
+                source: e.into(),
+            })
         })?;
 
         let output = decoder.get_mut();
@@ -170,13 +172,13 @@ impl GzipDecompressContext {
         let decoder = self
             .decoder
             .take()
-            .ok_or_else(|| Error::new(Status::GenericFailure, "gzip stream already finished"))?;
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("gzip stream")))?;
 
         decoder.finish().map(|v| v.into()).map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("gzip stream finish failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "gzip stream finish",
+                source: e.into(),
+            })
         })
     }
 }
@@ -196,10 +198,10 @@ impl DeflateCompressContext {
     pub fn new(level: Option<u32>) -> Result<Self> {
         let level = level.unwrap_or(DEFAULT_LEVEL);
         if level > 9 {
-            return Err(Error::new(
-                Status::InvalidArg,
-                "deflate compression level must be between 0 and 9",
-            ));
+            return Err(ZflateError::InvalidArg(
+                "deflate compression level must be between 0 and 9".to_string(),
+            )
+            .into());
         }
         let encoder = DeflateEncoder::new(Vec::new(), Compression::new(level));
         Ok(Self {
@@ -214,13 +216,13 @@ impl DeflateCompressContext {
         let encoder = self
             .encoder
             .as_mut()
-            .ok_or_else(|| Error::new(Status::GenericFailure, "deflate stream already finished"))?;
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("deflate stream")))?;
 
         encoder.write_all(crate::as_bytes(&chunk)).map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("deflate stream compress failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "deflate stream compress",
+                source: e.into(),
+            })
         })?;
 
         let output = encoder.get_mut();
@@ -234,13 +236,13 @@ impl DeflateCompressContext {
         let encoder = self
             .encoder
             .as_mut()
-            .ok_or_else(|| Error::new(Status::GenericFailure, "deflate stream already finished"))?;
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("deflate stream")))?;
 
         encoder.flush().map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("deflate stream flush failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "deflate stream flush",
+                source: e.into(),
+            })
         })?;
 
         let output = encoder.get_mut();
@@ -255,13 +257,13 @@ impl DeflateCompressContext {
         let encoder = self
             .encoder
             .take()
-            .ok_or_else(|| Error::new(Status::GenericFailure, "deflate stream already finished"))?;
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("deflate stream")))?;
 
         encoder.finish().map(|v| v.into()).map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("deflate stream finish failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "deflate stream finish",
+                source: e.into(),
+            })
         })
     }
 }
@@ -292,13 +294,13 @@ impl DeflateDecompressContext {
         let decoder = self
             .decoder
             .as_mut()
-            .ok_or_else(|| Error::new(Status::GenericFailure, "deflate stream already finished"))?;
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("deflate stream")))?;
 
         decoder.write_all(crate::as_bytes(&chunk)).map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("deflate stream decompress failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "deflate stream decompress",
+                source: e.into(),
+            })
         })?;
 
         let output = decoder.get_mut();
@@ -312,13 +314,13 @@ impl DeflateDecompressContext {
         let decoder = self
             .decoder
             .as_mut()
-            .ok_or_else(|| Error::new(Status::GenericFailure, "deflate stream already finished"))?;
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("deflate stream")))?;
 
         decoder.flush().map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("deflate stream flush failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "deflate stream flush",
+                source: e.into(),
+            })
         })?;
 
         let output = decoder.get_mut();
@@ -333,13 +335,13 @@ impl DeflateDecompressContext {
         let decoder = self
             .decoder
             .take()
-            .ok_or_else(|| Error::new(Status::GenericFailure, "deflate stream already finished"))?;
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("deflate stream")))?;
 
         decoder.finish().map(|v| v.into()).map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("deflate stream finish failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "deflate stream finish",
+                source: e.into(),
+            })
         })
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,6 +3,7 @@
 mod brotli_impl;
 mod brotli_stream;
 mod detect;
+mod error;
 mod gzip;
 mod gzip_stream;
 mod zstd;
@@ -10,6 +11,8 @@ mod zstd_stream;
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
+
+pub use error::ZflateError;
 
 /// Extract byte slice from Either<Buffer, Uint8Array>.
 fn as_bytes(data: &Either<Buffer, Uint8Array>) -> &[u8] {

--- a/crates/core/src/zstd.rs
+++ b/crates/core/src/zstd.rs
@@ -4,6 +4,8 @@ use napi::Task;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
+use crate::ZflateError;
+
 /// Default compression level for zstd (same as the C library default).
 const DEFAULT_LEVEL: i32 = 3;
 
@@ -23,7 +25,13 @@ pub fn zstd_compress(data: Either<Buffer, Uint8Array>, level: Option<i32>) -> Re
 
     zstd::bulk::compress(input, level)
         .map(|v| v.into())
-        .map_err(|e| Error::new(Status::GenericFailure, format!("zstd compress failed: {e}")))
+        .map_err(|e| {
+            ZflateError::Operation {
+                context: "zstd compress",
+                source: e.into(),
+            }
+            .into()
+        })
 }
 
 pub struct ZstdCompressTask {
@@ -37,8 +45,13 @@ impl Task for ZstdCompressTask {
     type JsValue = Buffer;
 
     fn compute(&mut self) -> Result<Self::Output> {
-        zstd::bulk::compress(&self.data, self.level)
-            .map_err(|e| Error::new(Status::GenericFailure, format!("zstd compress failed: {e}")))
+        zstd::bulk::compress(&self.data, self.level).map_err(|e| {
+            ZflateError::Operation {
+                context: "zstd compress",
+                source: e.into(),
+            }
+            .into()
+        })
     }
 
     fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
@@ -81,10 +94,11 @@ impl Task for ZstdDecompressTask {
         let capacity = capacity.max(1024);
 
         zstd::bulk::decompress(&self.data, capacity).map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("zstd decompress failed: {e}"),
-            )
+            ZflateError::Operation {
+                context: "zstd decompress",
+                source: e.into(),
+            }
+            .into()
         })
     }
 
@@ -125,10 +139,11 @@ pub fn zstd_decompress(data: Either<Buffer, Uint8Array>) -> Result<Buffer> {
     zstd::bulk::decompress(input, capacity)
         .map(|v| v.into())
         .map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("zstd decompress failed: {e}"),
-            )
+            ZflateError::Operation {
+                context: "zstd decompress",
+                source: e.into(),
+            }
+            .into()
         })
 }
 
@@ -142,10 +157,10 @@ pub fn zstd_decompress_with_capacity(
     capacity: f64,
 ) -> Result<Buffer> {
     if !capacity.is_finite() || capacity < 0.0 {
-        return Err(Error::new(
-            Status::InvalidArg,
-            "capacity must be a positive finite number",
-        ));
+        return Err(ZflateError::InvalidArg(
+            "capacity must be a positive finite number".to_string(),
+        )
+        .into());
     }
     let input = crate::as_bytes(&data);
     let cap = capacity as usize;
@@ -153,10 +168,11 @@ pub fn zstd_decompress_with_capacity(
     zstd::bulk::decompress(input, cap)
         .map(|v| v.into())
         .map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("zstd decompress failed: {e}"),
-            )
+            ZflateError::Operation {
+                context: "zstd decompress",
+                source: e.into(),
+            }
+            .into()
         })
 }
 
@@ -186,10 +202,11 @@ pub fn zstd_train_dictionary(
     zstd::dict::from_samples(&sample_vecs, max_size)
         .map(|v| v.into())
         .map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("zstd dictionary training failed: {e}"),
-            )
+            ZflateError::Operation {
+                context: "zstd dictionary training",
+                source: e.into(),
+            }
+            .into()
         })
 }
 
@@ -209,17 +226,17 @@ pub fn zstd_compress_with_dict(
 
     let mut compressor =
         zstd::bulk::Compressor::with_dictionary(level, dict_bytes).map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("zstd compressor init failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "zstd compressor init",
+                source: e.into(),
+            })
         })?;
 
     compressor.compress(input).map(|v| v.into()).map_err(|e| {
-        Error::new(
-            Status::GenericFailure,
-            format!("zstd compress with dict failed: {e}"),
-        )
+        napi::Error::from(ZflateError::Operation {
+            context: "zstd compress with dict",
+            source: e.into(),
+        })
     })
 }
 
@@ -241,20 +258,20 @@ pub fn zstd_decompress_with_dict(
     let capacity = capacity.max(1024);
 
     let mut decompressor = zstd::bulk::Decompressor::with_dictionary(dict_bytes).map_err(|e| {
-        Error::new(
-            Status::GenericFailure,
-            format!("zstd decompressor init failed: {e}"),
-        )
+        napi::Error::from(ZflateError::Operation {
+            context: "zstd decompressor init",
+            source: e.into(),
+        })
     })?;
 
     decompressor
         .decompress(input, capacity)
         .map(|v| v.into())
         .map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("zstd decompress with dict failed: {e}"),
-            )
+            napi::Error::from(ZflateError::Operation {
+                context: "zstd decompress with dict",
+                source: e.into(),
+            })
         })
 }
 

--- a/crates/core/src/zstd_stream.rs
+++ b/crates/core/src/zstd_stream.rs
@@ -4,6 +4,8 @@ use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use zstd::stream::raw::{Decoder, Encoder, InBuffer, Operation, OutBuffer};
 
+use crate::ZflateError;
+
 /// Default compression level for zstd (same as the C library default).
 const DEFAULT_LEVEL: i32 = 3;
 
@@ -24,10 +26,10 @@ impl ZstdCompressContext {
     #[napi(constructor)]
     pub fn new(level: Option<i32>) -> Result<Self> {
         let encoder = Encoder::new(level.unwrap_or(DEFAULT_LEVEL)).map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("failed to create zstd encoder: {e}"),
-            )
+            napi::Error::from(ZflateError::Creation {
+                context: "zstd encoder",
+                source: e.into(),
+            })
         })?;
         Ok(Self { encoder })
     }
@@ -46,10 +48,10 @@ impl ZstdCompressContext {
         while in_buf.pos() < in_buf.src.len() {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
             self.encoder.run(&mut in_buf, &mut out_buf).map_err(|e| {
-                Error::new(
-                    Status::GenericFailure,
-                    format!("zstd stream compress failed: {e}"),
-                )
+                napi::Error::from(ZflateError::Operation {
+                    context: "zstd stream compress",
+                    source: e.into(),
+                })
             })?;
             total_written = out_buf.pos();
             if total_written >= output.len() {
@@ -70,10 +72,10 @@ impl ZstdCompressContext {
         loop {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
             let remaining = self.encoder.flush(&mut out_buf).map_err(|e| {
-                Error::new(
-                    Status::GenericFailure,
-                    format!("zstd stream flush failed: {e}"),
-                )
+                napi::Error::from(ZflateError::Operation {
+                    context: "zstd stream flush",
+                    source: e.into(),
+                })
             })?;
             total_written = out_buf.pos();
             if remaining == 0 {
@@ -98,10 +100,10 @@ impl ZstdCompressContext {
         loop {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
             let remaining = self.encoder.finish(&mut out_buf, true).map_err(|e| {
-                Error::new(
-                    Status::GenericFailure,
-                    format!("zstd stream finish failed: {e}"),
-                )
+                napi::Error::from(ZflateError::Operation {
+                    context: "zstd stream finish",
+                    source: e.into(),
+                })
             })?;
             total_written = out_buf.pos();
             if remaining == 0 {
@@ -131,10 +133,10 @@ impl ZstdDecompressContext {
     #[napi(constructor)]
     pub fn new() -> Result<Self> {
         let decoder = Decoder::new().map_err(|e| {
-            Error::new(
-                Status::GenericFailure,
-                format!("failed to create zstd decoder: {e}"),
-            )
+            napi::Error::from(ZflateError::Creation {
+                context: "zstd decoder",
+                source: e.into(),
+            })
         })?;
         Ok(Self { decoder })
     }
@@ -153,10 +155,10 @@ impl ZstdDecompressContext {
         while in_buf.pos() < in_buf.src.len() {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
             self.decoder.run(&mut in_buf, &mut out_buf).map_err(|e| {
-                Error::new(
-                    Status::GenericFailure,
-                    format!("zstd stream decompress failed: {e}"),
-                )
+                napi::Error::from(ZflateError::Operation {
+                    context: "zstd stream decompress",
+                    source: e.into(),
+                })
             })?;
             total_written = out_buf.pos();
             if total_written >= output.len() {
@@ -177,10 +179,10 @@ impl ZstdDecompressContext {
         loop {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
             let remaining = self.decoder.flush(&mut out_buf).map_err(|e| {
-                Error::new(
-                    Status::GenericFailure,
-                    format!("zstd stream flush failed: {e}"),
-                )
+                napi::Error::from(ZflateError::Operation {
+                    context: "zstd stream flush",
+                    source: e.into(),
+                })
             })?;
             total_written = out_buf.pos();
             if remaining == 0 {


### PR DESCRIPTION
## Summary

- Add `thiserror` dependency and define `ZflateError` enum with 5 variants: `Operation`, `Creation`, `InvalidArg`, `SizeLimit`, `StreamFinished`
- Implement `From<ZflateError> for napi::Error` with correct status code mapping (`InvalidArg` → `Status::InvalidArg`, others → `Status::GenericFailure`)
- Migrate all 83 `Error::new()` call sites across 7 source files to use `ZflateError`
- All error messages remain exactly the same — full backward compatibility

Closes #51

## Test plan

- [x] `cargo clippy` passes
- [x] `cargo test` passes (42 tests)
- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (298 tests)
- [x] All existing tests pass **without any test changes** — confirms error message compatibility