### PR TITLE
test(bun): add Bun WASM smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'crates/**'
       - '__test__/**'
+      - 'e2e/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'Cargo.toml'
@@ -28,6 +29,7 @@ on:
     paths:
       - 'crates/**'
       - '__test__/**'
+      - 'e2e/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'Cargo.toml'
@@ -321,6 +323,27 @@ jobs:
           path: .
       - name: Run Deno WASM tests
         run: pnpm run test:deno
+
+  test-bun:
+    name: Bun WASM Test
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - run: pnpm install --frozen-lockfile
+      - name: Download WASM artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: bindings-wasm32
+          path: .
+      - name: Run Bun WASM tests
+        run: pnpm run test:bun
 
   coverage:
     name: Coverage

--- a/e2e/wasm-bun.test.ts
+++ b/e2e/wasm-bun.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test';
+
+// Bun does not support node:wasi (wasi.initialize is undefined),
+// so we use the browser loader which works via @napi-rs/wasm-runtime.
+const wasm = await import('../zflate.wasi-browser.js');
+
+function arrayEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+const testData = new TextEncoder().encode('Hello, Bun WASM zflate! '.repeat(100));
+
+describe('zflate WASM on Bun', () => {
+  test('zstd round-trip', () => {
+    const compressed = wasm.zstdCompress(testData);
+    const decompressed = wasm.zstdDecompress(compressed);
+    expect(arrayEqual(new Uint8Array(decompressed), testData)).toBe(true);
+  });
+
+  test('gzip round-trip', () => {
+    const compressed = wasm.gzipCompress(testData);
+    const decompressed = wasm.gzipDecompress(compressed);
+    expect(arrayEqual(new Uint8Array(decompressed), testData)).toBe(true);
+  });
+
+  test('deflate round-trip', () => {
+    const compressed = wasm.deflateCompress(testData);
+    const decompressed = wasm.deflateDecompress(compressed);
+    expect(arrayEqual(new Uint8Array(decompressed), testData)).toBe(true);
+  });
+
+  test('brotli round-trip', () => {
+    const compressed = wasm.brotliCompress(testData);
+    const decompressed = wasm.brotliDecompress(compressed);
+    expect(arrayEqual(new Uint8Array(decompressed), testData)).toBe(true);
+  });
+
+  test('auto-detect decompression', () => {
+    const compressed = wasm.zstdCompress(testData);
+    const decompressed = wasm.decompress(compressed);
+    expect(arrayEqual(new Uint8Array(decompressed), testData)).toBe(true);
+  });
+
+  test('version', () => {
+    const ver = wasm.version();
+    expect(typeof ver).toBe('string');
+    expect(ver).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "test": "vitest run",
     "test:deno": "deno test --allow-read --allow-env --allow-net --node-modules-dir=auto e2e/wasm-deno.test.ts",
     "test:wasm": "vitest run __test__/wasm.spec.ts",
+    "test:bun": "bun test e2e/wasm-bun.test.ts",
     "test:watch": "vitest watch",
     "bench": "vitest bench",
     "attw": "attw --pack .",


### PR DESCRIPTION
## Summary

- Add Bun WASM smoke test (`e2e/wasm-bun.test.ts`) that validates round-trip compression for all supported algorithms (zstd, gzip, deflate, brotli) plus auto-detect decompression and version check
- Uses the browser loader (`zflate.wasi-browser.js`) instead of `node:wasi` because Bun's WASI support is incomplete (`wasi.initialize` is undefined)
- Add `test:bun` npm script and corresponding CI job that runs after the WASM build

## Related issue

Closes #89

## Checklist

- [x] Test file created at `e2e/wasm-bun.test.ts`
- [x] `test:bun` npm script added
- [x] CI job `test-bun` added to `.github/workflows/ci.yml`
- [x] `e2e/**` added to CI path triggers
- [x] Biome lint passes
- [x] TypeScript typecheck passes
- [x] Vitest tests pass
- [x] Cargo test and clippy pass