### PR TITLE
test(deno): add Deno WASM smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ on:
       - 'index.d.mts'
       - 'node.js'
       - 'node.d.ts'
+      - 'e2e/**'
   pull_request:
     branches: [develop]
     paths:
@@ -43,6 +44,7 @@ on:
       - 'index.d.mts'
       - 'node.js'
       - 'node.d.ts'
+      - 'e2e/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -296,6 +298,29 @@ jobs:
           path: .
       - name: Run WASM tests
         run: pnpm run test:wasm
+
+  test-deno:
+    name: Deno WASM Test
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2
+        with:
+          deno-version: v2.x
+      - run: pnpm install --frozen-lockfile
+      - name: Download WASM artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: bindings-wasm32
+          path: .
+      - name: Run Deno WASM tests
+        run: pnpm run test:deno
 
   coverage:
     name: Coverage

--- a/e2e/wasm-deno.test.ts
+++ b/e2e/wasm-deno.test.ts
@@ -1,0 +1,60 @@
+// Deno does not support the WASI CJS loader (Context is not supported),
+// so we use the browser loader which works via @napi-rs/wasm-runtime.
+const wasm = await import('../zflate.wasi-browser.js');
+
+function arrayEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+const testData = new TextEncoder().encode('Hello, Deno WASM zflate! '.repeat(100));
+
+Deno.test('zstd round-trip', () => {
+  const compressed = wasm.zstdCompress(testData);
+  const decompressed = wasm.zstdDecompress(compressed);
+  if (!arrayEqual(new Uint8Array(decompressed), testData)) {
+    throw new Error('zstd round-trip failed');
+  }
+});
+
+Deno.test('gzip round-trip', () => {
+  const compressed = wasm.gzipCompress(testData);
+  const decompressed = wasm.gzipDecompress(compressed);
+  if (!arrayEqual(new Uint8Array(decompressed), testData)) {
+    throw new Error('gzip round-trip failed');
+  }
+});
+
+Deno.test('deflate round-trip', () => {
+  const compressed = wasm.deflateCompress(testData);
+  const decompressed = wasm.deflateDecompress(compressed);
+  if (!arrayEqual(new Uint8Array(decompressed), testData)) {
+    throw new Error('deflate round-trip failed');
+  }
+});
+
+Deno.test('brotli round-trip', () => {
+  const compressed = wasm.brotliCompress(testData);
+  const decompressed = wasm.brotliDecompress(compressed);
+  if (!arrayEqual(new Uint8Array(decompressed), testData)) {
+    throw new Error('brotli round-trip failed');
+  }
+});
+
+Deno.test('auto-detect decompression', () => {
+  const compressed = wasm.zstdCompress(testData);
+  const decompressed = wasm.decompress(compressed);
+  if (!arrayEqual(new Uint8Array(decompressed), testData)) {
+    throw new Error('auto-detect failed');
+  }
+});
+
+Deno.test('version', () => {
+  const ver = wasm.version();
+  if (typeof ver !== 'string' || !/^\d+\.\d+\.\d+/.test(ver)) {
+    throw new Error(`Invalid version: ${ver}`);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "lint:fix": "biome check --write",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:deno": "deno test --allow-read --allow-env --allow-net --node-modules-dir=auto e2e/wasm-deno.test.ts",
     "test:wasm": "vitest run __test__/wasm.spec.ts",
     "test:watch": "vitest watch",
     "bench": "vitest bench",


### PR DESCRIPTION
## Summary

- Add Deno WASM smoke test (`e2e/wasm-deno.test.ts`) that verifies zstd, gzip, deflate, and brotli round-trip compression, auto-detect decompression, and version check
- Deno does not support the WASI CJS loader (`node:wasi` Context), so the test uses the browser loader (`*.wasi-browser.js`) which works via `@napi-rs/wasm-runtime`
- Add `test:deno` npm script and `test-deno` CI job (runs after WASM build, uses `denoland/setup-deno` v2)
- Add `e2e/**` to CI trigger paths

## Related issue

Closes #88

## Checklist

- [x] Test file created at `e2e/wasm-deno.test.ts`
- [x] `test:deno` npm script added
- [x] CI job `test-deno` added to `.github/workflows/ci.yml`
- [x] CI trigger paths updated to include `e2e/**`
- [x] Follows rapid-fuzzy pattern with pinned action hashes
- [x] Biome lint passes
- [x] TypeScript typecheck passes
- [x] Cargo test passes
- [x] Cargo clippy passes