### PR TITLE
ci(security): tighten cargo-deny bans and sources to deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -14,10 +14,10 @@ allow = [
 ]
 
 [bans]
-multiple-versions = "warn"
+multiple-versions = "deny"
 
 [sources]
-unknown-registry = "warn"
-unknown-git = "warn"
+unknown-registry = "deny"
+unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = []


### PR DESCRIPTION
## Summary

- Change `[bans] multiple-versions` from `"warn"` to `"deny"` to catch duplicate crate versions that bloat the binary
- Change `[sources] unknown-registry` from `"warn"` to `"deny"` to block dependencies from untrusted registries
- Change `[sources] unknown-git` from `"warn"` to `"deny"` to block git dependencies not explicitly allowed

No skip entries were needed — the current dependency tree has no violations.

## Related issue

Closes #105

## Checklist

- [x] All three settings changed from `warn` to `deny`
- [x] `cargo deny check` passes
- [x] `cargo test` passes (42 tests)
- [x] `cargo clippy` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存関係の検証ポリシーを強化しました。複数バージョンの依存関係、未知のレジストリ、未知のGitソースについて、警告から拒否に変更しました。これにより、プロジェクトのセキュリティと安定性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->