### PR TITLE
fix(core): add decompression size limits to streaming contexts

### DIFF
--- a/crates/core/src/brotli_stream.rs
+++ b/crates/core/src/brotli_stream.rs
@@ -13,6 +13,9 @@ const DEFAULT_QUALITY: u32 = 6;
 /// Default buffer size for brotli operations.
 const BUFFER_SIZE: usize = 4096;
 
+/// Maximum allowed decompressed size (256 MB) to prevent memory exhaustion.
+const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
+
 /// Default log2 of the sliding window size for brotli.
 const LG_WINDOW_SIZE: u32 = 22;
 
@@ -99,6 +102,7 @@ impl BrotliCompressContext {
 #[napi]
 pub struct BrotliDecompressContext {
     decompressor: brotli::DecompressorWriter<Vec<u8>>,
+    total_output: usize,
 }
 
 #[napi]
@@ -106,7 +110,10 @@ impl BrotliDecompressContext {
     #[napi(constructor)]
     pub fn new() -> Result<Self> {
         let decompressor = brotli::DecompressorWriter::new(Vec::new(), BUFFER_SIZE);
-        Ok(Self { decompressor })
+        Ok(Self {
+            decompressor,
+            total_output: 0,
+        })
     }
 
     /// Decompress a chunk of compressed data. Returns decompressed output
@@ -125,6 +132,14 @@ impl BrotliDecompressContext {
         // Drain whatever the decompressor has written to the inner Vec
         let output = self.decompressor.get_ref().clone();
         self.decompressor.get_mut().clear();
+        self.total_output += output.len();
+        if self.total_output > MAX_DECOMPRESSED_SIZE {
+            return Err(ZflateError::SizeLimit {
+                context: "brotli stream decompress",
+                limit: MAX_DECOMPRESSED_SIZE,
+            }
+            .into());
+        }
         Ok(output.into())
     }
 

--- a/crates/core/src/gzip_stream.rs
+++ b/crates/core/src/gzip_stream.rs
@@ -12,6 +12,9 @@ use crate::ZflateError;
 /// Default compression level for gzip/deflate (same as zlib default).
 const DEFAULT_LEVEL: u32 = 6;
 
+/// Maximum allowed decompressed size (256 MB) to prevent memory exhaustion.
+const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
+
 /// Streaming gzip compression context.
 ///
 /// Maintains internal compression state across multiple `transform` calls,
@@ -104,6 +107,7 @@ impl GzipCompressContext {
 #[napi]
 pub struct GzipDecompressContext {
     decoder: Option<GzDecoder<Vec<u8>>>,
+    total_output: usize,
 }
 
 #[napi]
@@ -113,6 +117,7 @@ impl GzipDecompressContext {
         let decoder = GzDecoder::new(Vec::new());
         Ok(Self {
             decoder: Some(decoder),
+            total_output: 0,
         })
     }
 
@@ -142,6 +147,14 @@ impl GzipDecompressContext {
 
         let output = decoder.get_mut();
         let data = output.split_off(0);
+        self.total_output += data.len();
+        if self.total_output > MAX_DECOMPRESSED_SIZE {
+            return Err(ZflateError::SizeLimit {
+                context: "gzip stream decompress",
+                limit: MAX_DECOMPRESSED_SIZE,
+            }
+            .into());
+        }
         Ok(data.into())
     }
 
@@ -275,6 +288,7 @@ impl DeflateCompressContext {
 #[napi]
 pub struct DeflateDecompressContext {
     decoder: Option<DeflateDecoder<Vec<u8>>>,
+    total_output: usize,
 }
 
 #[napi]
@@ -284,6 +298,7 @@ impl DeflateDecompressContext {
         let decoder = DeflateDecoder::new(Vec::new());
         Ok(Self {
             decoder: Some(decoder),
+            total_output: 0,
         })
     }
 
@@ -305,6 +320,14 @@ impl DeflateDecompressContext {
 
         let output = decoder.get_mut();
         let data = output.split_off(0);
+        self.total_output += data.len();
+        if self.total_output > MAX_DECOMPRESSED_SIZE {
+            return Err(ZflateError::SizeLimit {
+                context: "deflate stream decompress",
+                limit: MAX_DECOMPRESSED_SIZE,
+            }
+            .into());
+        }
         Ok(data.into())
     }
 

--- a/crates/core/src/zstd_stream.rs
+++ b/crates/core/src/zstd_stream.rs
@@ -12,6 +12,9 @@ const DEFAULT_LEVEL: i32 = 3;
 /// Initial output buffer size for streaming operations.
 const INITIAL_BUF_SIZE: usize = 128 * 1024;
 
+/// Maximum allowed decompressed size (256 MB) to prevent memory exhaustion.
+const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
+
 /// Streaming zstd compression context.
 ///
 /// Maintains internal compression state across multiple `transform` calls,
@@ -126,6 +129,7 @@ impl ZstdCompressContext {
 #[napi]
 pub struct ZstdDecompressContext {
     decoder: Decoder<'static>,
+    total_output: usize,
 }
 
 #[napi]
@@ -138,7 +142,10 @@ impl ZstdDecompressContext {
                 source: e.into(),
             })
         })?;
-        Ok(Self { decoder })
+        Ok(Self {
+            decoder,
+            total_output: 0,
+        })
     }
 
     /// Decompress a chunk of compressed data. Returns decompressed output
@@ -161,11 +168,19 @@ impl ZstdDecompressContext {
                 })
             })?;
             total_written = out_buf.pos();
+            if self.total_output + total_written > MAX_DECOMPRESSED_SIZE {
+                return Err(ZflateError::SizeLimit {
+                    context: "zstd stream decompress",
+                    limit: MAX_DECOMPRESSED_SIZE,
+                }
+                .into());
+            }
             if total_written >= output.len() {
                 output.resize(output.len() * 2, 0);
             }
         }
 
+        self.total_output += total_written;
         output.truncate(total_written);
         Ok(output.into())
     }


### PR DESCRIPTION
## Summary

- Add cumulative output size tracking (`total_output: usize`) to all 4 streaming decompression contexts
- Enforce `MAX_DECOMPRESSED_SIZE` (256 MB) across `transform()` calls
- Prevents decompression bomb attacks via streaming APIs that previously had no size limit
- One-shot decompress functions already had this protection; now streaming matches

Closes #97

## Test plan

- [x] `cargo clippy` passes
- [x] `cargo test` passes (42 tests)
- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (298 tests)
- [x] Existing streaming round-trip tests pass (data well under 256 MB)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**新機能**
* デコンプレッション操作に256MBのサイズ上限を追加しました。この上限を超える場合、エラーが返されます。Brotli、Gzip、Deflate、Zstdの全てのデコンプレッション形式に対応しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->