### PR TITLE
feat(core): narrow detectFormat return type to string enum

### DIFF
--- a/crates/core/src/detect.rs
+++ b/crates/core/src/detect.rs
@@ -13,6 +13,19 @@ const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
 /// Gzip magic number: 0x1F 0x8B.
 const GZIP_MAGIC: [u8; 2] = [0x1F, 0x8B];
 
+/// Compression format detected from input data.
+#[napi(string_enum)]
+pub enum CompressionFormat {
+    #[napi(value = "zstd")]
+    Zstd,
+    #[napi(value = "gzip")]
+    Gzip,
+    #[napi(value = "brotli")]
+    Brotli,
+    #[napi(value = "unknown")]
+    Unknown,
+}
+
 /// Detect the compression format of the given data.
 ///
 /// Returns `"zstd"`, `"gzip"`, or `"brotli"`.
@@ -23,9 +36,14 @@ const GZIP_MAGIC: [u8; 2] = [0x1F, 0x8B];
 /// if it appears to start with a valid brotli stream. Otherwise, `"unknown"`
 /// is returned.
 #[napi]
-pub fn detect_format(data: Either<Buffer, Uint8Array>) -> String {
+pub fn detect_format(data: Either<Buffer, Uint8Array>) -> CompressionFormat {
     let input = crate::as_bytes(&data);
-    detect(input).to_string()
+    match detect(input) {
+        Format::Zstd => CompressionFormat::Zstd,
+        Format::Gzip => CompressionFormat::Gzip,
+        Format::Brotli => CompressionFormat::Brotli,
+        Format::Unknown => CompressionFormat::Unknown,
+    }
 }
 
 /// Decompress data by auto-detecting the compression format.

--- a/index.d.ts
+++ b/index.d.ts
@@ -206,6 +206,14 @@ export declare function brotliDecompressAsync(data: Buffer | Uint8Array): Promis
  */
 export declare function brotliDecompressWithCapacity(data: Buffer | Uint8Array, capacity: number): Buffer
 
+/** Compression format detected from input data. */
+export declare const enum CompressionFormat {
+  Zstd = 'zstd',
+  Gzip = 'gzip',
+  Brotli = 'brotli',
+  Unknown = 'unknown'
+}
+
 /**
  * Decompress data by auto-detecting the compression format.
  *
@@ -271,7 +279,7 @@ export declare function deflateDecompressWithCapacity(data: Buffer | Uint8Array,
  * if it appears to start with a valid brotli stream. Otherwise, `"unknown"`
  * is returned.
  */
-export declare function detectFormat(data: Buffer | Uint8Array): string
+export declare function detectFormat(data: Buffer | Uint8Array): CompressionFormat
 
 /**
  * Compress data using gzip.

--- a/index.js
+++ b/index.js
@@ -589,6 +589,7 @@ module.exports.brotliCompressAsync = nativeBinding.brotliCompressAsync
 module.exports.brotliDecompress = nativeBinding.brotliDecompress
 module.exports.brotliDecompressAsync = nativeBinding.brotliDecompressAsync
 module.exports.brotliDecompressWithCapacity = nativeBinding.brotliDecompressWithCapacity
+module.exports.CompressionFormat = nativeBinding.CompressionFormat
 module.exports.decompress = nativeBinding.decompress
 module.exports.deflateCompress = nativeBinding.deflateCompress
 module.exports.deflateCompressAsync = nativeBinding.deflateCompressAsync

--- a/index.mjs
+++ b/index.mjs
@@ -23,6 +23,7 @@ export const {
   zstdTrainDictionary,
   zstdCompressWithDict,
   zstdDecompressWithDict,
+  CompressionFormat,
   decompress,
   detectFormat,
   gzipCompress,


### PR DESCRIPTION
## Summary

- Add `CompressionFormat` enum with `#[napi(string_enum)]` for type-safe format detection
- `detectFormat()` now returns `CompressionFormat` (`'zstd' | 'gzip' | 'brotli' | 'unknown'`) instead of `string`
- Export `CompressionFormat` enum from ESM entry point
- Runtime values unchanged — existing tests pass without modification

Closes #103

## Test plan

- [x] `cargo clippy` passes
- [x] `cargo test` passes (42 tests)
- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (298 tests)