### PR TITLE
perf(core): eliminate unnecessary Vec clone in streaming contexts

### DIFF
--- a/crates/core/src/brotli_stream.rs
+++ b/crates/core/src/brotli_stream.rs
@@ -58,9 +58,8 @@ impl BrotliCompressContext {
             })?;
 
         // Drain whatever the compressor has flushed to the inner Vec
-        let output = self.compressor.get_ref().clone();
-        self.compressor.get_mut().clear();
-        Ok(output.into())
+        let data = std::mem::take(self.compressor.get_mut());
+        Ok(data.into())
     }
 
     /// Flush the compressor's internal buffer. Returns any buffered compressed data.
@@ -73,9 +72,8 @@ impl BrotliCompressContext {
             })
         })?;
 
-        let output = self.compressor.get_ref().clone();
-        self.compressor.get_mut().clear();
-        Ok(output.into())
+        let data = std::mem::take(self.compressor.get_mut());
+        Ok(data.into())
     }
 
     /// Finalize the compression stream. Writes the brotli stream footer.
@@ -130,9 +128,8 @@ impl BrotliDecompressContext {
             })?;
 
         // Drain whatever the decompressor has written to the inner Vec
-        let output = self.decompressor.get_ref().clone();
-        self.decompressor.get_mut().clear();
-        self.total_output += output.len();
+        let data = std::mem::take(self.decompressor.get_mut());
+        self.total_output += data.len();
         if self.total_output > MAX_DECOMPRESSED_SIZE {
             return Err(ZflateError::SizeLimit {
                 context: "brotli stream decompress",
@@ -140,7 +137,7 @@ impl BrotliDecompressContext {
             }
             .into());
         }
-        Ok(output.into())
+        Ok(data.into())
     }
 
     /// Flush the decompressor's internal buffer. Returns any buffered decompressed data.
@@ -153,9 +150,8 @@ impl BrotliDecompressContext {
             })
         })?;
 
-        let output = self.decompressor.get_ref().clone();
-        self.decompressor.get_mut().clear();
-        Ok(output.into())
+        let data = std::mem::take(self.decompressor.get_mut());
+        Ok(data.into())
     }
 }
 

--- a/crates/core/src/gzip_stream.rs
+++ b/crates/core/src/gzip_stream.rs
@@ -58,7 +58,7 @@ impl GzipCompressContext {
         })?;
 
         let output = encoder.get_mut();
-        let data = output.split_off(0);
+        let data = std::mem::take(output);
         Ok(data.into())
     }
 
@@ -78,7 +78,7 @@ impl GzipCompressContext {
         })?;
 
         let output = encoder.get_mut();
-        let data = output.split_off(0);
+        let data = std::mem::take(output);
         Ok(data.into())
     }
 
@@ -146,7 +146,7 @@ impl GzipDecompressContext {
         }
 
         let output = decoder.get_mut();
-        let data = output.split_off(0);
+        let data = std::mem::take(output);
         self.total_output += data.len();
         if self.total_output > MAX_DECOMPRESSED_SIZE {
             return Err(ZflateError::SizeLimit {
@@ -174,7 +174,7 @@ impl GzipDecompressContext {
         })?;
 
         let output = decoder.get_mut();
-        let data = output.split_off(0);
+        let data = std::mem::take(output);
         Ok(data.into())
     }
 
@@ -239,7 +239,7 @@ impl DeflateCompressContext {
         })?;
 
         let output = encoder.get_mut();
-        let data = output.split_off(0);
+        let data = std::mem::take(output);
         Ok(data.into())
     }
 
@@ -259,7 +259,7 @@ impl DeflateCompressContext {
         })?;
 
         let output = encoder.get_mut();
-        let data = output.split_off(0);
+        let data = std::mem::take(output);
         Ok(data.into())
     }
 
@@ -319,7 +319,7 @@ impl DeflateDecompressContext {
         })?;
 
         let output = decoder.get_mut();
-        let data = output.split_off(0);
+        let data = std::mem::take(output);
         self.total_output += data.len();
         if self.total_output > MAX_DECOMPRESSED_SIZE {
             return Err(ZflateError::SizeLimit {
@@ -347,7 +347,7 @@ impl DeflateDecompressContext {
         })?;
 
         let output = decoder.get_mut();
-        let data = output.split_off(0);
+        let data = std::mem::take(output);
         Ok(data.into())
     }
 


### PR DESCRIPTION
## Summary

- Replace `.get_ref().clone()` + `.get_mut().clear()` with `std::mem::take()` in 4 brotli streaming locations — eliminates full Vec copy on every transform/flush call
- Replace `.split_off(0)` with `std::mem::take()` in 8 gzip/deflate streaming locations — avoids allocating a new empty Vec

Closes #99

## Test plan

- [x] `cargo clippy` passes
- [x] `cargo test` passes (42 tests)
- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (298 tests)