### PR TITLE
perf(zstd): enable multi-threaded compression for native targets

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,5 +16,8 @@ zstd = { workspace = true }
 flate2 = { workspace = true }
 thiserror = { workspace = true }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+zstd = { workspace = true, features = ["zstdmt"] }
+
 [build-dependencies]
 napi-build = { workspace = true }


### PR DESCRIPTION
## Summary

- Enable `zstdmt` feature for non-WASM targets via `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]`
- This activates zstd's internal thread pool (`ZSTD_MULTITHREAD`) for native builds
- WASM is excluded due to experimental wasi-threads and untested napi-rs interaction
- No API changes — multi-threading is used internally by zstd when beneficial

Closes #102

## Test plan

- [x] `cargo clippy` passes
- [x] `cargo test` passes (42 tests)
- [x] `pnpm run build` passes
- [x] `pnpm test` passes (306 tests)
- [ ] CI WASM build must pass (zstdmt excluded for wasm32)
- [ ] CI native builds must pass (zstdmt included)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * 非WASM32プラットフォームにおけるパフォーマンスの最適化を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->