### PR TITLE
docs: comprehensive README update with missing APIs and SVG benchmark

### DIFF
--- a/.github/assets/bench-compress.svg
+++ b/.github/assets/bench-compress.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 220" width="680" height="220">
+<style>
+  text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+  .title { font-size: 16px; font-weight: 600; fill: #1f2937; }
+  .subtitle { font-size: 12px; fill: #6b7280; }
+  .bar-label { font-size: 12px; fill: #4b5563; }
+  .bar-value { font-size: 12px; fill: #374151; font-weight: 500; }
+  .multiplier { font-size: 11px; fill: #059669; font-weight: 600; }
+</style>
+<rect width="680" height="220" rx="8" fill="#ffffff" />
+<rect x="0.5" y="0.5" width="679" height="219" rx="8" fill="none" stroke="#e5e7eb" />
+<text x="20" y="28" class="title">Gzip Compression — 10 KB</text>
+<text x="20" y="44" class="subtitle">Apple M1 · Node.js 24 · ops/sec (higher is better)</text>
+<text x="112" y="78" class="bar-label" text-anchor="end">zflate</text>
+<rect x="120" y="60" width="360" height="28" rx="4" fill="#3b82f6" />
+<text x="488" y="78" class="bar-value">40,350 ops/s</text>
+<text x="112" y="114" class="bar-label" text-anchor="end">node:zlib</text>
+<rect x="120" y="96" width="247.86" height="28" rx="4" fill="#94a3b8" opacity="0.65" />
+<text x="375.86" y="114" class="bar-value">27,790 ops/s</text>
+<text x="112" y="150" class="bar-label" text-anchor="end">fflate</text>
+<rect x="120" y="132" width="93.71" height="28" rx="4" fill="#94a3b8" opacity="0.65" />
+<text x="221.71" y="150" class="bar-value">10,503 ops/s</text>
+<text x="312.71" y="150" class="multiplier">3.8x vs fflate</text>
+<text x="112" y="186" class="bar-label" text-anchor="end">pako</text>
+<rect x="120" y="168" width="66.01" height="28" rx="4" fill="#94a3b8" opacity="0.65" />
+<text x="194.01" y="186" class="bar-value">7,400 ops/s</text>
+<text x="285.01" y="186" class="multiplier">5.5x vs pako</text>
+</svg>

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/zflate)](https://www.npmjs.com/package/zflate)
 [![CI](https://github.com/derodero24/zflate/actions/workflows/ci.yml/badge.svg)](https://github.com/derodero24/zflate/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/derodero24/zflate/graph/badge.svg)](https://codecov.io/gh/derodero24/zflate)
+[![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json&repo=derodero24/zflate)](https://codspeed.io/derodero24/zflate)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 Rust-powered universal compression for JavaScript/TypeScript. **zstd**, **gzip**, and **brotli** in one package.
@@ -101,6 +102,37 @@ zstdCompress(data, 22);
 zstdCompress(data, -1);
 ```
 
+### Auto-detect
+
+```typescript
+import { decompress } from 'zflate';
+
+// Works with any supported format — no need to know the algorithm
+const decompressed = decompress(compressedData);
+```
+
+### Async
+
+```typescript
+import { gzipCompressAsync, gzipDecompressAsync } from 'zflate';
+
+const compressed = await gzipCompressAsync(data);
+const decompressed = await gzipDecompressAsync(compressed);
+```
+
+### Dictionary
+
+```typescript
+import { zstdTrainDictionary, zstdCompressWithDict, zstdDecompressWithDict } from 'zflate';
+
+// Train from samples of similar data
+const dict = zstdTrainDictionary(samples);
+
+// Compress/decompress with dictionary
+const compressed = zstdCompressWithDict(data, dict);
+const decompressed = zstdDecompressWithDict(compressed, dict);
+```
+
 ## API
 
 ### One-shot
@@ -119,8 +151,10 @@ zstdCompress(data, -1);
 | --- | --- |
 | `gzipCompress(data, level?)` | Compress with gzip. Level: 0-9 (default: 6) |
 | `gzipDecompress(data)` | Decompress gzip data |
+| `gzipDecompressWithCapacity(data, capacity)` | Decompress with explicit output size limit |
 | `deflateCompress(data, level?)` | Compress with raw deflate. Level: 0-9 (default: 6) |
 | `deflateDecompress(data)` | Decompress raw deflate data |
+| `deflateDecompressWithCapacity(data, capacity)` | Decompress with explicit output size limit |
 
 #### brotli
 
@@ -129,6 +163,36 @@ zstdCompress(data, -1);
 | `brotliCompress(data, quality?)` | Compress with brotli. Quality: 0-11 (default: 6) |
 | `brotliDecompress(data)` | Decompress brotli data (max 256 MB output) |
 | `brotliDecompressWithCapacity(data, capacity)` | Decompress with explicit output size limit |
+
+#### Auto-detect
+
+| Function | Description |
+| --- | --- |
+| `decompress(data)` | Auto-detect format and decompress (zstd, gzip, brotli) |
+| `detectFormat(data)` | Detect compression format. Returns `'zstd'`, `'gzip'`, `'brotli'`, or `'unknown'` |
+
+#### zstd Dictionary
+
+| Function | Description |
+| --- | --- |
+| `zstdTrainDictionary(samples, maxDictSize?)` | Train a dictionary from sample data (default max: 110 KB) |
+| `zstdCompressWithDict(data, dict, level?)` | Compress with pre-trained dictionary |
+| `zstdDecompressWithDict(data, dict)` | Decompress dictionary-compressed data |
+
+### Async
+
+All one-shot functions have async variants that run on the libuv thread pool, keeping the event loop free:
+
+| Function | Description |
+| --- | --- |
+| `zstdCompressAsync(data, level?)` | Async zstd compression |
+| `zstdDecompressAsync(data)` | Async zstd decompression |
+| `gzipCompressAsync(data, level?)` | Async gzip compression |
+| `gzipDecompressAsync(data)` | Async gzip decompression |
+| `deflateCompressAsync(data, level?)` | Async deflate compression |
+| `deflateDecompressAsync(data)` | Async deflate decompression |
+| `brotliCompressAsync(data, quality?)` | Async brotli compression |
+| `brotliDecompressAsync(data)` | Async brotli decompression |
 
 ### Streaming
 
@@ -142,6 +206,37 @@ zstdCompress(data, -1);
 | `createDeflateDecompressStream()` | Create a raw deflate decompression `TransformStream` |
 | `createBrotliCompressStream(quality?)` | Create a brotli compression `TransformStream` |
 | `createBrotliDecompressStream()` | Create a brotli decompression `TransformStream` |
+| `createZstdCompressDictStream(dict, level?)` | Streaming zstd compression with dictionary |
+| `createZstdDecompressDictStream(dict)` | Streaming zstd decompression with dictionary |
+
+### Node.js Transform Streams
+
+For Node.js `stream.pipeline()` compatibility, import from `zflate/node`:
+
+```typescript
+import { createGzipCompressTransform } from 'zflate/node';
+import { pipeline } from 'node:stream/promises';
+import { createReadStream, createWriteStream } from 'node:fs';
+
+await pipeline(
+  createReadStream('input.txt'),
+  createGzipCompressTransform(),
+  createWriteStream('output.gz'),
+);
+```
+
+| Function | Description |
+| --- | --- |
+| `createZstdCompressTransform(level?)` | Node.js Transform for zstd compression |
+| `createZstdDecompressTransform()` | Node.js Transform for zstd decompression |
+| `createGzipCompressTransform(level?)` | Node.js Transform for gzip compression |
+| `createGzipDecompressTransform()` | Node.js Transform for gzip decompression |
+| `createDeflateCompressTransform(level?)` | Node.js Transform for deflate compression |
+| `createDeflateDecompressTransform()` | Node.js Transform for deflate decompression |
+| `createBrotliCompressTransform(quality?)` | Node.js Transform for brotli compression |
+| `createBrotliDecompressTransform()` | Node.js Transform for brotli decompression |
+| `createZstdCompressDictTransform(dict, level?)` | Node.js Transform for zstd dict compression |
+| `createZstdDecompressDictTransform(dict)` | Node.js Transform for zstd dict decompression |
 
 ## Supported Algorithms
 
@@ -163,6 +258,10 @@ zstdCompress(data, -1);
 ### Build targets
 
 `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-gnu`, `aarch64-unknown-linux-musl`, `x86_64-pc-windows-msvc`, `aarch64-pc-windows-msvc`, `wasm32-wasip1-threads`
+
+### WASM bundle size
+
+The WASM binary (`wasm32-wasip1-threads`) is optimized with `wasm-opt -O3` during the build process. Binary size is tracked and reported in CI on every build — check the latest [CI run summary](https://github.com/derodero24/zflate/actions/workflows/ci.yml) for current numbers.
 
 ## Browser Usage
 
@@ -222,15 +321,16 @@ const decompressed = gzipDecompress(compressed);
 + const decompressed = gzipDecompress(compressed);
 ```
 
-### WASM bundle size
-
-The WASM binary (`wasm32-wasip1-threads`) is optimized with `wasm-opt -O3` during the build process. Binary size is tracked and reported in CI on every build — check the latest [CI run summary](https://github.com/derodero24/zflate/actions/workflows/ci.yml) for current numbers.
-
 ## Benchmarks
 
-Measured on Apple M1, Node.js v22 (zstd level 3, gzip/brotli level 6):
+<img src=".github/assets/bench-compress.svg" alt="Compression benchmark chart" width="680" />
 
-### Compression throughput
+<details>
+<summary>Raw benchmark data</summary>
+
+Measured on Apple M1, Node.js v24:
+
+### zstd compression throughput
 
 | Data type | Size | ops/sec |
 | --- | --- | --- |
@@ -243,7 +343,7 @@ Measured on Apple M1, Node.js v22 (zstd level 3, gzip/brotli level 6):
 | JSON | 84KB | 9,104 |
 | Text | 45KB | 56,757 |
 
-### Decompression throughput
+### zstd decompression throughput
 
 | Data type | Size | ops/sec |
 | --- | --- | --- |
@@ -255,6 +355,8 @@ Measured on Apple M1, Node.js v22 (zstd level 3, gzip/brotli level 6):
 | Random | 1MB | 3,797 |
 | JSON | 84KB | 15,034 |
 | Text | 45KB | 37,599 |
+
+</details>
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Add CodSpeed badge to badge row
- Expand API reference with missing sections: auto-detect (`decompress`, `detectFormat`), zstd dictionary (`zstdTrainDictionary`, `zstdCompressWithDict`, `zstdDecompressWithDict`), async variants for all algorithms, and Node.js Transform Streams (`zflate/node`)
- Add `gzipDecompressWithCapacity` and `deflateDecompressWithCapacity` to gzip/deflate table
- Add dictionary streaming functions (`createZstdCompressDictStream`, `createZstdDecompressDictStream`) to streaming table
- Add Quick Start examples for auto-detect, async, and dictionary APIs
- Create SVG horizontal bar chart (`.github/assets/bench-compress.svg`) comparing gzip compression performance
- Replace raw benchmark tables with SVG chart and collapsible details section
- Move WASM bundle size section from between Migration and Benchmarks to under Platform Support > Build targets

## Related issue

Closes #117

## Checklist

- [x] `pnpm run check` passes
- [x] All new API entries verified against `index.d.ts`, `streams.d.ts`, `node.d.ts`
- [x] SVG chart follows rapid-fuzzy style conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * 拡張されたREADMEドキュメント、新しいAPI機能の詳細説明を追加

* **新機能**
  * 圧縮フォーマット自動検出機能
  * すべての圧縮アルゴリズム対応の非同期API
  * zstd辞書サポート機能
  * Node.js Transform Stream統合
  * 容量指定デコンプレッション関数

<!-- end of auto-generated comment: release notes by coderabbit.ai -->