### PR TITLE
fix(docs): correct benchmark environment label to Apple M2 / Node.js v22

### DIFF
--- a/.github/assets/bench-compress.svg
+++ b/.github/assets/bench-compress.svg
@@ -10,7 +10,7 @@
 <rect width="680" height="220" rx="8" fill="#ffffff" />
 <rect x="0.5" y="0.5" width="679" height="219" rx="8" fill="none" stroke="#e5e7eb" />
 <text x="20" y="28" class="title">Gzip Compression — 10 KB</text>
-<text x="20" y="44" class="subtitle">Apple M1 · Node.js 24 · ops/sec (higher is better)</text>
+<text x="20" y="44" class="subtitle">Apple M2 · Node.js v22 · ops/sec (higher is better)</text>
 <text x="112" y="78" class="bar-label" text-anchor="end">zflate</text>
 <rect x="120" y="60" width="360" height="28" rx="4" fill="#3b82f6" />
 <text x="488" y="78" class="bar-value">40,350 ops/s</text>

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ const decompressed = gzipDecompress(compressed);
 <details>
 <summary>Raw benchmark data</summary>
 
-Measured on Apple M1, Node.js v24:
+Measured on Apple M2, Node.js v22:
 
 ### zstd compression throughput
 


### PR DESCRIPTION
## Summary

The benchmark environment label incorrectly stated "Apple M1 · Node.js 24" but the benchmarks were run on Apple M2 with Node.js v22. Fixed in both the SVG chart and the README raw data section.

## Changes

- `.github/assets/bench-compress.svg`: "Apple M1 · Node.js 24" → "Apple M2 · Node.js v22"
- `README.md`: "Apple M1, Node.js v24" → "Apple M2, Node.js v22"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * ベンチマーク計測データを最新の測定条件に合わせて更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->