### PR TITLE
perf(wasm): add --converge flag to wasm-opt optimization

### DIFF
--- a/scripts/optimize-wasm.js
+++ b/scripts/optimize-wasm.js
@@ -65,9 +65,9 @@ for (const wasmFile of wasmFiles) {
   try {
     // wasm-opt in-place: write to temp then rename
     const tmpFile = `${wasmFile}.opt`;
-    execFileSync(wasmOpt, [optLevel, '--all-features', '-o', tmpFile, wasmFile], {
+    execFileSync(wasmOpt, [optLevel, '--all-features', '--converge', '-o', tmpFile, wasmFile], {
       stdio: 'pipe',
-      timeout: 120_000,
+      timeout: 300_000,
     });
     fs.renameSync(tmpFile, wasmFile);
 


### PR DESCRIPTION
## Summary

- Add `--converge` flag to `wasm-opt` invocation to re-run optimization passes until no further gains
- Increase timeout from 2 to 5 minutes to accommodate additional passes
- Expected 1-3% additional WASM binary size reduction

Closes #121

## Test plan

- [x] Script syntax is correct
- [ ] CI WASM build passes with new flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ビルド改善**
  * WASM最適化処理がより詳細な最適化技術を採用しました。
  * ビルド処理の最大実行時間を延長することで、より高度な最適化結果を実現できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->