### PR TITLE
perf(core): improve decompression output pre-allocation heuristic

### DIFF
--- a/crates/core/src/brotli_impl.rs
+++ b/crates/core/src/brotli_impl.rs
@@ -59,7 +59,7 @@ pub fn brotli_decompress(data: Either<Buffer, Uint8Array>) -> Result<Buffer> {
     let input = crate::as_bytes(&data);
     let mut decompressor = brotli::Decompressor::new(input, BUFFER_SIZE);
 
-    let mut output = Vec::with_capacity(input.len().min(MAX_DECOMPRESSED_SIZE));
+    let mut output = Vec::with_capacity((input.len() * 4).min(MAX_DECOMPRESSED_SIZE));
     let mut buf = [0u8; BUFFER_SIZE];
 
     loop {
@@ -104,7 +104,7 @@ pub fn brotli_decompress_with_capacity(
     let cap = capacity as usize;
 
     let mut decompressor = brotli::Decompressor::new(input, BUFFER_SIZE);
-    let mut output = Vec::with_capacity(input.len().min(cap));
+    let mut output = Vec::with_capacity((input.len() * 4).min(cap));
     let mut buf = [0u8; BUFFER_SIZE];
 
     loop {
@@ -200,7 +200,7 @@ impl Task for BrotliDecompressTask {
 
     fn compute(&mut self) -> Result<Self::Output> {
         let mut decompressor = brotli::Decompressor::new(self.data.as_slice(), BUFFER_SIZE);
-        let mut output = Vec::with_capacity(self.data.len().min(MAX_DECOMPRESSED_SIZE));
+        let mut output = Vec::with_capacity((self.data.len() * 4).min(MAX_DECOMPRESSED_SIZE));
         let mut buf = [0u8; BUFFER_SIZE];
 
         loop {

--- a/crates/core/src/gzip.rs
+++ b/crates/core/src/gzip.rs
@@ -80,7 +80,7 @@ pub fn gzip_decompress_with_capacity(
 
 fn decompress_gzip_with_limit(input: &[u8], max_size: usize) -> Result<Buffer> {
     let mut decoder = GzDecoder::new(input);
-    let mut output = Vec::with_capacity(input.len().min(max_size));
+    let mut output = Vec::with_capacity((input.len() * 4).min(max_size));
     let mut buf = [0u8; BUFFER_SIZE];
 
     loop {
@@ -166,7 +166,7 @@ pub fn deflate_decompress_with_capacity(
 
 fn decompress_deflate_with_limit(input: &[u8], max_size: usize) -> Result<Buffer> {
     let mut decoder = DeflateDecoder::new(input);
-    let mut output = Vec::with_capacity(input.len().min(max_size));
+    let mut output = Vec::with_capacity((input.len() * 4).min(max_size));
     let mut buf = [0u8; BUFFER_SIZE];
 
     loop {
@@ -259,7 +259,7 @@ impl Task for GzipDecompressTask {
 
     fn compute(&mut self) -> Result<Self::Output> {
         let mut decoder = GzDecoder::new(self.data.as_slice());
-        let mut output = Vec::with_capacity(self.data.len().min(MAX_DECOMPRESSED_SIZE));
+        let mut output = Vec::with_capacity((self.data.len() * 4).min(MAX_DECOMPRESSED_SIZE));
         let mut buf = [0u8; BUFFER_SIZE];
 
         loop {
@@ -366,7 +366,7 @@ impl Task for DeflateDecompressTask {
 
     fn compute(&mut self) -> Result<Self::Output> {
         let mut decoder = DeflateDecoder::new(self.data.as_slice());
-        let mut output = Vec::with_capacity(self.data.len().min(MAX_DECOMPRESSED_SIZE));
+        let mut output = Vec::with_capacity((self.data.len() * 4).min(MAX_DECOMPRESSED_SIZE));
         let mut buf = [0u8; BUFFER_SIZE];
 
         loop {


### PR DESCRIPTION
## Summary

- Change decompression output Vec pre-allocation from `input.len()` to `input.len() * 4` across all 7 decompression locations (gzip, deflate, brotli — sync, async, and with-capacity variants)
- Compressed data typically expands 2-10x; `input.len()` caused excessive Vec reallocations
- `.min(max_size)` caps are preserved to bound allocation within `MAX_DECOMPRESSED_SIZE` (256 MB)
- On 64-bit systems, unused reserved capacity only consumes virtual address space

Closes #120

## Test plan

- [x] `cargo clippy` passes
- [x] `cargo test` passes (42 tests)
- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (306 tests)