### PR TITLE
fix(gzip): support concatenated gzip streams in decompression

### DIFF
--- a/__test__/async.spec.ts
+++ b/__test__/async.spec.ts
@@ -102,6 +102,14 @@ describe('gzip async', () => {
     const invalid = Buffer.from('not gzip data');
     await expect(gzipDecompressAsync(invalid)).rejects.toThrow();
   });
+
+  it('should decompress concatenated gzip streams', async () => {
+    const a = gzipCompress(Buffer.from('Hello'));
+    const b = gzipCompress(Buffer.from(' World'));
+    const concatenated = Buffer.concat([a, b]);
+    const result = await gzipDecompressAsync(concatenated);
+    expect(result.toString()).toBe('Hello World');
+  });
 });
 
 describe('deflate async', () => {

--- a/__test__/detect.spec.ts
+++ b/__test__/detect.spec.ts
@@ -111,4 +111,12 @@ describe('decompress (auto-detect)', () => {
     const result = decompress(uint8);
     expect(Buffer.compare(result, original)).toBe(0);
   });
+
+  it('should auto-decompress concatenated gzip streams', () => {
+    const a = gzipCompress(Buffer.from('Part1'));
+    const b = gzipCompress(Buffer.from('Part2'));
+    const concatenated = Buffer.concat([a, b]);
+    const result = decompress(concatenated);
+    expect(result.toString()).toBe('Part1Part2');
+  });
 });

--- a/__test__/gzip-streaming.spec.ts
+++ b/__test__/gzip-streaming.spec.ts
@@ -116,6 +116,15 @@ describe('createGzipDecompressStream', () => {
     const decompressed = await collectStream(stream.pipeThrough(createGzipDecompressStream()));
     expect(Buffer.compare(decompressed, data)).toBe(0);
   });
+
+  it('should handle concatenated gzip streams', async () => {
+    const a = gzipCompress(Buffer.from('Hello'));
+    const b = gzipCompress(Buffer.from(' World'));
+    const concatenated = Buffer.concat([a, b]);
+    const stream = toChunkedStream(concatenated, concatenated.length);
+    const decompressed = await collectStream(stream.pipeThrough(createGzipDecompressStream()));
+    expect(decompressed.toString()).toBe('Hello World');
+  });
 });
 
 describe('gzip streaming round-trip', () => {

--- a/__test__/gzip.spec.ts
+++ b/__test__/gzip.spec.ts
@@ -99,6 +99,14 @@ describe('gzipCompress / gzipDecompress', () => {
     const result = gzipDecompress(compressed);
     expect(Buffer.compare(result, random)).toBe(0);
   });
+
+  it('should decompress concatenated gzip streams', () => {
+    const a = gzipCompress(Buffer.from('Hello'));
+    const b = gzipCompress(Buffer.from(' World'));
+    const concatenated = Buffer.concat([a, b]);
+    const result = gzipDecompress(concatenated);
+    expect(result.toString()).toBe('Hello World');
+  });
 });
 
 describe('gzipDecompressWithCapacity', () => {
@@ -143,6 +151,14 @@ describe('gzipDecompressWithCapacity', () => {
     const result = gzipDecompressWithCapacity(emptyCompressed, 0);
     expect(result.length).toBe(0);
   });
+
+  it('should decompress concatenated gzip streams with capacity', () => {
+    const a = gzipCompress(Buffer.from('Hello'));
+    const b = gzipCompress(Buffer.from(' World'));
+    const concatenated = Buffer.concat([a, b]);
+    const result = gzipDecompressWithCapacity(concatenated, 1024);
+    expect(result.toString()).toBe('Hello World');
+  });
 });
 
 describe('gzip interop with Node.js zlib', () => {
@@ -165,6 +181,14 @@ describe('gzip interop with Node.js zlib', () => {
     // Gzip magic number: 0x1f 0x8b
     expect(compressed[0]).toBe(0x1f);
     expect(compressed[1]).toBe(0x8b);
+  });
+
+  it('should decompress concatenated gzip streams from Node.js zlib', () => {
+    const a = gzipSync(Buffer.from('Part1'));
+    const b = gzipSync(Buffer.from('Part2'));
+    const concatenated = Buffer.concat([a, b]);
+    const result = gzipDecompress(concatenated);
+    expect(result.toString()).toBe('Part1Part2');
   });
 });
 

--- a/crates/core/src/gzip.rs
+++ b/crates/core/src/gzip.rs
@@ -3,7 +3,7 @@
 use std::io::{Read, Write};
 
 use flate2::Compression;
-use flate2::read::{DeflateDecoder, GzDecoder};
+use flate2::read::{DeflateDecoder, MultiGzDecoder};
 use flate2::write::{DeflateEncoder, GzEncoder};
 use napi::Task;
 use napi::bindgen_prelude::*;
@@ -79,7 +79,7 @@ pub fn gzip_decompress_with_capacity(
 }
 
 fn decompress_gzip_with_limit(input: &[u8], max_size: usize) -> Result<Buffer> {
-    let mut decoder = GzDecoder::new(input);
+    let mut decoder = MultiGzDecoder::new(input);
     let mut output = Vec::with_capacity((input.len() * 4).min(max_size));
     let mut buf = [0u8; BUFFER_SIZE];
 
@@ -258,7 +258,7 @@ impl Task for GzipDecompressTask {
     type JsValue = Buffer;
 
     fn compute(&mut self) -> Result<Self::Output> {
-        let mut decoder = GzDecoder::new(self.data.as_slice());
+        let mut decoder = MultiGzDecoder::new(self.data.as_slice());
         let mut output = Vec::with_capacity((self.data.len() * 4).min(MAX_DECOMPRESSED_SIZE));
         let mut buf = [0u8; BUFFER_SIZE];
 
@@ -421,7 +421,7 @@ mod tests {
         encoder.write_all(original).unwrap();
         let compressed = encoder.finish().unwrap();
 
-        let mut decoder = GzDecoder::new(compressed.as_slice());
+        let mut decoder = MultiGzDecoder::new(compressed.as_slice());
         let mut decompressed = Vec::new();
         decoder.read_to_end(&mut decompressed).unwrap();
         assert_eq!(original.as_slice(), decompressed.as_slice());
@@ -434,7 +434,7 @@ mod tests {
         encoder.write_all(original).unwrap();
         let compressed = encoder.finish().unwrap();
 
-        let mut decoder = GzDecoder::new(compressed.as_slice());
+        let mut decoder = MultiGzDecoder::new(compressed.as_slice());
         let mut decompressed = Vec::new();
         decoder.read_to_end(&mut decompressed).unwrap();
         assert_eq!(original.as_slice(), decompressed.as_slice());
@@ -447,7 +447,7 @@ mod tests {
         encoder.write_all(&original).unwrap();
         let compressed = encoder.finish().unwrap();
 
-        let mut decoder = GzDecoder::new(compressed.as_slice());
+        let mut decoder = MultiGzDecoder::new(compressed.as_slice());
         let mut decompressed = Vec::new();
         decoder.read_to_end(&mut decompressed).unwrap();
         assert_eq!(original, decompressed);
@@ -507,7 +507,7 @@ mod tests {
         encoder.write_all(&original).unwrap();
         let compressed = encoder.finish().unwrap();
 
-        let mut decoder = GzDecoder::new(compressed.as_slice());
+        let mut decoder = MultiGzDecoder::new(compressed.as_slice());
         let mut output = Vec::new();
         let mut buf = [0u8; BUFFER_SIZE];
         let mut exceeded = false;
@@ -532,7 +532,7 @@ mod tests {
         encoder.write_all(original).unwrap();
         let compressed = encoder.finish().unwrap();
 
-        let mut decoder = GzDecoder::new(compressed.as_slice());
+        let mut decoder = MultiGzDecoder::new(compressed.as_slice());
         let mut output = Vec::new();
         let mut buf = [0u8; BUFFER_SIZE];
         let mut exceeded = false;
@@ -614,5 +614,27 @@ mod tests {
         let mut decompressed = Vec::new();
         decoder.read_to_end(&mut decompressed).unwrap();
         assert_eq!(original.as_slice(), decompressed.as_slice());
+    }
+
+    #[test]
+    fn gzip_concatenated_round_trip() {
+        let part_a = b"Hello";
+        let part_b = b" World";
+
+        let mut enc_a = GzEncoder::new(Vec::new(), Compression::new(DEFAULT_LEVEL));
+        enc_a.write_all(part_a).unwrap();
+        let compressed_a = enc_a.finish().unwrap();
+
+        let mut enc_b = GzEncoder::new(Vec::new(), Compression::new(DEFAULT_LEVEL));
+        enc_b.write_all(part_b).unwrap();
+        let compressed_b = enc_b.finish().unwrap();
+
+        let mut concatenated = compressed_a;
+        concatenated.extend_from_slice(&compressed_b);
+
+        let mut decoder = MultiGzDecoder::new(concatenated.as_slice());
+        let mut decompressed = Vec::new();
+        decoder.read_to_end(&mut decompressed).unwrap();
+        assert_eq!(b"Hello World", decompressed.as_slice());
     }
 }

--- a/crates/core/src/gzip_stream.rs
+++ b/crates/core/src/gzip_stream.rs
@@ -3,7 +3,7 @@
 use std::io::Write;
 
 use flate2::Compression;
-use flate2::write::{DeflateDecoder, DeflateEncoder, GzDecoder, GzEncoder};
+use flate2::write::{DeflateDecoder, DeflateEncoder, GzEncoder, MultiGzDecoder};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
@@ -106,7 +106,7 @@ impl GzipCompressContext {
 /// enabling chunked decompression of a gzip stream.
 #[napi]
 pub struct GzipDecompressContext {
-    decoder: Option<GzDecoder<Vec<u8>>>,
+    decoder: Option<MultiGzDecoder<Vec<u8>>>,
     total_output: usize,
 }
 
@@ -114,7 +114,7 @@ pub struct GzipDecompressContext {
 impl GzipDecompressContext {
     #[napi(constructor)]
     pub fn new() -> Result<Self> {
-        let decoder = GzDecoder::new(Vec::new());
+        let decoder = MultiGzDecoder::new(Vec::new());
         Ok(Self {
             decoder: Some(decoder),
             total_output: 0,


### PR DESCRIPTION
## Summary

- Replace `GzDecoder` with `MultiGzDecoder` in all gzip decompression paths (one-shot, async, streaming)
- Concatenated gzip streams (RFC 1952 §2.2) are now correctly decompressed with all members included
- Affects `gzipDecompress`, `gzipDecompressAsync`, `gzipDecompressWithCapacity`, `GzipDecompressContext`, and auto-detect `decompress`

## Changes

- `crates/core/src/gzip.rs`: `flate2::read::GzDecoder` → `MultiGzDecoder` in `decompress_gzip_with_limit()` and `GzipDecompressTask`
- `crates/core/src/gzip_stream.rs`: `flate2::write::GzDecoder` → `MultiGzDecoder` in `GzipDecompressContext`
- Added concatenated gzip tests: sync, async, streaming, capacity, Node.js interop, and auto-detect

## Test plan

- [x] Rust tests pass (43 tests)
- [x] JS tests pass (312 tests)
- [x] cargo clippy clean
- [x] Biome lint clean
- [x] TypeScript typecheck clean
- [x] New tests verify concatenated gzip decompression across all API surfaces

Closes #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 複数の連結されたgzipストリームの処理に対応しました。

* **テスト**
  * 連結されたgzipデータの圧縮解除機能を検証する新しいテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->