### PR TITLE
fix(streaming): add finish-guard for brotli and zstd compress contexts

### DIFF
--- a/__test__/edge-cases.spec.ts
+++ b/__test__/edge-cases.spec.ts
@@ -11,6 +11,7 @@ import {
   GzipDecompressContext,
   gzipCompress,
   gzipDecompress,
+  ZstdCompressContext,
   zstdCompress,
   zstdDecompress,
 } from '../index.js';
@@ -275,6 +276,60 @@ describe('streaming edge cases', () => {
       ctx.transform(compressed);
       ctx.finish();
       expect(() => ctx.finish()).toThrow(/already finished/);
+    });
+  });
+
+  describe('transform after finish on brotli compress context', () => {
+    it('should throw when calling transform() after finish() on BrotliCompressContext', () => {
+      const ctx = new BrotliCompressContext();
+      ctx.transform(Buffer.from('hello'));
+      ctx.finish();
+      expect(() => ctx.transform(Buffer.from('more data'))).toThrow(/already finished/);
+    });
+  });
+
+  describe('finish twice on brotli compress context', () => {
+    it('should throw when calling finish() twice on BrotliCompressContext', () => {
+      const ctx = new BrotliCompressContext();
+      ctx.transform(Buffer.from('hello'));
+      ctx.finish();
+      expect(() => ctx.finish()).toThrow(/already finished/);
+    });
+  });
+
+  describe('flush after finish on brotli compress context', () => {
+    it('should throw when calling flush() after finish() on BrotliCompressContext', () => {
+      const ctx = new BrotliCompressContext();
+      ctx.transform(Buffer.from('hello'));
+      ctx.finish();
+      expect(() => ctx.flush()).toThrow(/already finished/);
+    });
+  });
+
+  describe('transform after finish on zstd compress context', () => {
+    it('should throw when calling transform() after finish() on ZstdCompressContext', () => {
+      const ctx = new ZstdCompressContext();
+      ctx.transform(Buffer.from('hello'));
+      ctx.finish();
+      expect(() => ctx.transform(Buffer.from('more data'))).toThrow(/already finished/);
+    });
+  });
+
+  describe('finish twice on zstd compress context', () => {
+    it('should throw when calling finish() twice on ZstdCompressContext', () => {
+      const ctx = new ZstdCompressContext();
+      ctx.transform(Buffer.from('hello'));
+      ctx.finish();
+      expect(() => ctx.finish()).toThrow(/already finished/);
+    });
+  });
+
+  describe('flush after finish on zstd compress context', () => {
+    it('should throw when calling flush() after finish() on ZstdCompressContext', () => {
+      const ctx = new ZstdCompressContext();
+      ctx.transform(Buffer.from('hello'));
+      ctx.finish();
+      expect(() => ctx.flush()).toThrow(/already finished/);
     });
   });
 

--- a/__test__/zstd-dict.spec.ts
+++ b/__test__/zstd-dict.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  ZstdCompressDictContext,
   zstdCompress,
   zstdCompressWithDict,
   zstdDecompressWithDict,
@@ -194,5 +195,42 @@ describe('zstd streaming dictionary compression', () => {
       decompStream.pipeThrough(createZstdDecompressDictStream(dict)),
     );
     expect(Buffer.compare(decompressed, original)).toBe(0);
+  });
+});
+
+describe('zstd dict compress context finish guard', () => {
+  const samples = Array.from({ length: 100 }, (_, i) =>
+    Buffer.from(
+      JSON.stringify({
+        id: i,
+        name: `user_${i}`,
+        email: `user${i}@example.com`,
+        active: i % 2 === 0,
+      }),
+    ),
+  );
+
+  it('should throw when calling transform() after finish() on ZstdCompressDictContext', () => {
+    const dict = zstdTrainDictionary(samples);
+    const ctx = new ZstdCompressDictContext(dict);
+    ctx.transform(Buffer.from('hello'));
+    ctx.finish();
+    expect(() => ctx.transform(Buffer.from('more data'))).toThrow(/already finished/);
+  });
+
+  it('should throw when calling finish() twice on ZstdCompressDictContext', () => {
+    const dict = zstdTrainDictionary(samples);
+    const ctx = new ZstdCompressDictContext(dict);
+    ctx.transform(Buffer.from('hello'));
+    ctx.finish();
+    expect(() => ctx.finish()).toThrow(/already finished/);
+  });
+
+  it('should throw when calling flush() after finish() on ZstdCompressDictContext', () => {
+    const dict = zstdTrainDictionary(samples);
+    const ctx = new ZstdCompressDictContext(dict);
+    ctx.transform(Buffer.from('hello'));
+    ctx.finish();
+    expect(() => ctx.flush()).toThrow(/already finished/);
   });
 });

--- a/crates/core/src/brotli_stream.rs
+++ b/crates/core/src/brotli_stream.rs
@@ -25,7 +25,7 @@ const LG_WINDOW_SIZE: u32 = 22;
 /// enabling chunked compression without losing cross-chunk context.
 #[napi]
 pub struct BrotliCompressContext {
-    compressor: brotli::CompressorWriter<Vec<u8>>,
+    compressor: Option<brotli::CompressorWriter<Vec<u8>>>,
 }
 
 #[napi]
@@ -41,38 +41,48 @@ impl BrotliCompressContext {
         }
         let compressor =
             brotli::CompressorWriter::new(Vec::new(), BUFFER_SIZE, quality, LG_WINDOW_SIZE);
-        Ok(Self { compressor })
+        Ok(Self {
+            compressor: Some(compressor),
+        })
     }
 
     /// Compress a chunk of data. Returns compressed output (may be empty if
     /// the compressor is buffering data internally).
     #[napi]
     pub fn transform(&mut self, chunk: Either<Buffer, Uint8Array>) -> Result<Buffer> {
-        self.compressor
-            .write_all(crate::as_bytes(&chunk))
-            .map_err(|e| {
-                napi::Error::from(ZflateError::Operation {
-                    context: "brotli stream compress",
-                    source: e.into(),
-                })
-            })?;
+        let compressor = self
+            .compressor
+            .as_mut()
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("brotli stream")))?;
+
+        compressor.write_all(crate::as_bytes(&chunk)).map_err(|e| {
+            napi::Error::from(ZflateError::Operation {
+                context: "brotli stream compress",
+                source: e.into(),
+            })
+        })?;
 
         // Drain whatever the compressor has flushed to the inner Vec
-        let data = std::mem::take(self.compressor.get_mut());
+        let data = std::mem::take(compressor.get_mut());
         Ok(data.into())
     }
 
     /// Flush the compressor's internal buffer. Returns any buffered compressed data.
     #[napi]
     pub fn flush(&mut self) -> Result<Buffer> {
-        self.compressor.flush().map_err(|e| {
+        let compressor = self
+            .compressor
+            .as_mut()
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("brotli stream")))?;
+
+        compressor.flush().map_err(|e| {
             napi::Error::from(ZflateError::Operation {
                 context: "brotli stream flush",
                 source: e.into(),
             })
         })?;
 
-        let data = std::mem::take(self.compressor.get_mut());
+        let data = std::mem::take(compressor.get_mut());
         Ok(data.into())
     }
 
@@ -80,11 +90,10 @@ impl BrotliCompressContext {
     /// Must be called once after all data has been transformed.
     #[napi]
     pub fn finish(&mut self) -> Result<Buffer> {
-        // Close the compressor by replacing it with a dummy and dropping the old one
-        let compressor = std::mem::replace(
-            &mut self.compressor,
-            brotli::CompressorWriter::new(Vec::new(), BUFFER_SIZE, 0, LG_WINDOW_SIZE),
-        );
+        let compressor = self
+            .compressor
+            .take()
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("brotli stream")))?;
 
         // into_inner drops the CompressorWriter, which flushes remaining data
         // and writes the brotli stream end marker

--- a/crates/core/src/zstd_stream.rs
+++ b/crates/core/src/zstd_stream.rs
@@ -21,7 +21,7 @@ const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
 /// enabling chunked compression without losing cross-chunk context.
 #[napi]
 pub struct ZstdCompressContext {
-    encoder: Encoder<'static>,
+    encoder: Option<Encoder<'static>>,
 }
 
 #[napi]
@@ -41,13 +41,20 @@ impl ZstdCompressContext {
                 source: e.into(),
             })
         })?;
-        Ok(Self { encoder })
+        Ok(Self {
+            encoder: Some(encoder),
+        })
     }
 
     /// Compress a chunk of data. Returns compressed output (may be empty if
     /// the encoder is buffering data internally).
     #[napi]
     pub fn transform(&mut self, chunk: Either<Buffer, Uint8Array>) -> Result<Buffer> {
+        let encoder = self
+            .encoder
+            .as_mut()
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("zstd stream")))?;
+
         let input = crate::as_bytes(&chunk);
         let bound = zstd::zstd_safe::compress_bound(input.len());
         let mut output = vec![0u8; bound.max(INITIAL_BUF_SIZE)];
@@ -57,7 +64,7 @@ impl ZstdCompressContext {
 
         while in_buf.pos() < in_buf.src.len() {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
-            self.encoder.run(&mut in_buf, &mut out_buf).map_err(|e| {
+            encoder.run(&mut in_buf, &mut out_buf).map_err(|e| {
                 napi::Error::from(ZflateError::Operation {
                     context: "zstd stream compress",
                     source: e.into(),
@@ -76,12 +83,17 @@ impl ZstdCompressContext {
     /// Flush the encoder's internal buffer. Returns any buffered compressed data.
     #[napi]
     pub fn flush(&mut self) -> Result<Buffer> {
+        let encoder = self
+            .encoder
+            .as_mut()
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("zstd stream")))?;
+
         let mut output = vec![0u8; INITIAL_BUF_SIZE];
         let mut total_written = 0;
 
         loop {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
-            let remaining = self.encoder.flush(&mut out_buf).map_err(|e| {
+            let remaining = encoder.flush(&mut out_buf).map_err(|e| {
                 napi::Error::from(ZflateError::Operation {
                     context: "zstd stream flush",
                     source: e.into(),
@@ -104,12 +116,17 @@ impl ZstdCompressContext {
     /// Must be called once after all data has been transformed.
     #[napi]
     pub fn finish(&mut self) -> Result<Buffer> {
+        let mut encoder = self
+            .encoder
+            .take()
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("zstd stream")))?;
+
         let mut output = vec![0u8; INITIAL_BUF_SIZE];
         let mut total_written = 0;
 
         loop {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
-            let remaining = self.encoder.finish(&mut out_buf, true).map_err(|e| {
+            let remaining = encoder.finish(&mut out_buf, true).map_err(|e| {
                 napi::Error::from(ZflateError::Operation {
                     context: "zstd stream finish",
                     source: e.into(),
@@ -226,7 +243,7 @@ impl ZstdDecompressContext {
 /// using a pre-trained dictionary for improved compression of small, similar data.
 #[napi]
 pub struct ZstdCompressDictContext {
-    encoder: Encoder<'static>,
+    encoder: Option<Encoder<'static>>,
 }
 
 #[napi]
@@ -247,13 +264,20 @@ impl ZstdCompressDictContext {
                 source: e.into(),
             })
         })?;
-        Ok(Self { encoder })
+        Ok(Self {
+            encoder: Some(encoder),
+        })
     }
 
     /// Compress a chunk of data. Returns compressed output (may be empty if
     /// the encoder is buffering data internally).
     #[napi]
     pub fn transform(&mut self, chunk: Either<Buffer, Uint8Array>) -> Result<Buffer> {
+        let encoder = self
+            .encoder
+            .as_mut()
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("zstd stream")))?;
+
         let input = crate::as_bytes(&chunk);
         let bound = zstd::zstd_safe::compress_bound(input.len());
         let mut output = vec![0u8; bound.max(INITIAL_BUF_SIZE)];
@@ -263,7 +287,7 @@ impl ZstdCompressDictContext {
 
         while in_buf.pos() < in_buf.src.len() {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
-            self.encoder.run(&mut in_buf, &mut out_buf).map_err(|e| {
+            encoder.run(&mut in_buf, &mut out_buf).map_err(|e| {
                 napi::Error::from(ZflateError::Operation {
                     context: "zstd stream compress",
                     source: e.into(),
@@ -282,12 +306,17 @@ impl ZstdCompressDictContext {
     /// Flush the encoder's internal buffer. Returns any buffered compressed data.
     #[napi]
     pub fn flush(&mut self) -> Result<Buffer> {
+        let encoder = self
+            .encoder
+            .as_mut()
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("zstd stream")))?;
+
         let mut output = vec![0u8; INITIAL_BUF_SIZE];
         let mut total_written = 0;
 
         loop {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
-            let remaining = self.encoder.flush(&mut out_buf).map_err(|e| {
+            let remaining = encoder.flush(&mut out_buf).map_err(|e| {
                 napi::Error::from(ZflateError::Operation {
                     context: "zstd stream flush",
                     source: e.into(),
@@ -310,12 +339,17 @@ impl ZstdCompressDictContext {
     /// Must be called once after all data has been transformed.
     #[napi]
     pub fn finish(&mut self) -> Result<Buffer> {
+        let mut encoder = self
+            .encoder
+            .take()
+            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("zstd stream")))?;
+
         let mut output = vec![0u8; INITIAL_BUF_SIZE];
         let mut total_written = 0;
 
         loop {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
-            let remaining = self.encoder.finish(&mut out_buf, true).map_err(|e| {
+            let remaining = encoder.finish(&mut out_buf, true).map_err(|e| {
                 napi::Error::from(ZflateError::Operation {
                     context: "zstd stream finish",
                     source: e.into(),


### PR DESCRIPTION
## Summary

- Add `Option` wrapping for internal encoder/compressor in `BrotliCompressContext`, `ZstdCompressContext`, and `ZstdCompressDictContext`
- `transform()`, `flush()`, and `finish()` now throw `StreamFinished` error after `finish()` is called
- Consistent with existing behavior in `GzipCompressContext` and `DeflateCompressContext`

## Changes

- `crates/core/src/brotli_stream.rs`: Wrap `compressor` field in `Option`, add finish-guard checks
- `crates/core/src/zstd_stream.rs`: Wrap `encoder` field in `Option` for both `ZstdCompressContext` and `ZstdCompressDictContext`
- `__test__/edge-cases.spec.ts`: 6 new tests for brotli and zstd finish-guard behavior
- `__test__/zstd-dict.spec.ts`: 3 new tests for dictionary compression finish-guard

## Test plan

- [x] Rust tests pass (42 tests)
- [x] JS tests pass (315 tests)
- [x] cargo clippy clean
- [x] Biome lint clean
- [x] TypeScript typecheck clean
- [x] New tests verify transform/flush/finish after finish() throws for all affected contexts

Closes #125