### PR TITLE
feat(streaming): add auto-detect decompression streams

### DIFF
--- a/__test__/decompress-stream.spec.ts
+++ b/__test__/decompress-stream.spec.ts
@@ -1,0 +1,154 @@
+import { Readable, Writable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { describe, expect, it } from 'vitest';
+import { brotliCompress, gzipCompress, zstdCompress } from '../index.js';
+import { createDecompressTransform } from '../node.js';
+import { createDecompressStream } from '../streams.js';
+
+/** Collect all chunks from a ReadableStream into a single Buffer. */
+async function collectStream(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
+  const chunks: Uint8Array[] = [];
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks);
+}
+
+/** Create a ReadableStream from data, split into chunks of the given size. */
+function toChunkedStream(data: Uint8Array, chunkSize: number): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (let i = 0; i < data.length; i += chunkSize) {
+        controller.enqueue(data.slice(i, i + chunkSize));
+      }
+      controller.close();
+    },
+  });
+}
+
+/** Create a Node.js Readable from data, split into chunks of the given size. */
+function toChunkedReadable(data: Buffer, chunkSize: number): Readable {
+  let offset = 0;
+  return new Readable({
+    read() {
+      if (offset >= data.length) {
+        this.push(null);
+        return;
+      }
+      const end = Math.min(offset + chunkSize, data.length);
+      this.push(data.subarray(offset, end));
+      offset = end;
+    },
+  });
+}
+
+/** Collect output from source piped through a transform into a Buffer. */
+async function collectTransform(
+  source: Readable,
+  transform: NodeJS.ReadWriteStream,
+): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  const sink = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(chunk);
+      callback();
+    },
+  });
+  await pipeline(source, transform, sink);
+  return Buffer.concat(chunks);
+}
+
+const original = Buffer.from('Hello, auto-detect streaming decompression! '.repeat(100));
+
+describe('createDecompressStream', () => {
+  it('should auto-detect and decompress zstd data', async () => {
+    const compressed = zstdCompress(original);
+    const stream = toChunkedStream(compressed, 64);
+    const result = await collectStream(stream.pipeThrough(createDecompressStream()));
+    expect(Buffer.compare(result, original)).toBe(0);
+  });
+
+  it('should auto-detect and decompress gzip data', async () => {
+    const compressed = gzipCompress(original);
+    const stream = toChunkedStream(compressed, 64);
+    const result = await collectStream(stream.pipeThrough(createDecompressStream()));
+    expect(Buffer.compare(result, original)).toBe(0);
+  });
+
+  it('should auto-detect and decompress brotli data', async () => {
+    const compressed = brotliCompress(original);
+    const stream = toChunkedStream(compressed, 64);
+    const result = await collectStream(stream.pipeThrough(createDecompressStream()));
+    expect(Buffer.compare(result, original)).toBe(0);
+  });
+
+  it('should handle small first chunk (< 4 bytes) with buffering', async () => {
+    const compressed = zstdCompress(original);
+    const stream = toChunkedStream(compressed, 2);
+    const result = await collectStream(stream.pipeThrough(createDecompressStream()));
+    expect(Buffer.compare(result, original)).toBe(0);
+  });
+
+  it('should throw on unknown format', async () => {
+    const data = Buffer.from('this is not compressed data at all');
+    const stream = toChunkedStream(data, 64);
+    await expect(collectStream(stream.pipeThrough(createDecompressStream()))).rejects.toThrow(
+      /unable to detect compression format/,
+    );
+  });
+
+  it('should handle single chunk', async () => {
+    const compressed = gzipCompress(original);
+    const stream = toChunkedStream(compressed, compressed.length);
+    const result = await collectStream(stream.pipeThrough(createDecompressStream()));
+    expect(Buffer.compare(result, original)).toBe(0);
+  });
+});
+
+describe('createDecompressTransform', () => {
+  it('should auto-detect and decompress zstd data', async () => {
+    const compressed = Buffer.from(zstdCompress(original));
+    const source = toChunkedReadable(compressed, 64);
+    const result = await collectTransform(source, createDecompressTransform());
+    expect(Buffer.compare(result, original)).toBe(0);
+  });
+
+  it('should auto-detect and decompress gzip data', async () => {
+    const compressed = Buffer.from(gzipCompress(original));
+    const source = toChunkedReadable(compressed, 64);
+    const result = await collectTransform(source, createDecompressTransform());
+    expect(Buffer.compare(result, original)).toBe(0);
+  });
+
+  it('should auto-detect and decompress brotli data', async () => {
+    const compressed = Buffer.from(brotliCompress(original));
+    const source = toChunkedReadable(compressed, 64);
+    const result = await collectTransform(source, createDecompressTransform());
+    expect(Buffer.compare(result, original)).toBe(0);
+  });
+
+  it('should handle small first chunk (< 4 bytes) with buffering', async () => {
+    const compressed = Buffer.from(zstdCompress(original));
+    const source = toChunkedReadable(compressed, 2);
+    const result = await collectTransform(source, createDecompressTransform());
+    expect(Buffer.compare(result, original)).toBe(0);
+  });
+
+  it('should throw on unknown format', async () => {
+    const data = Buffer.from('this is not compressed data at all');
+    const source = toChunkedReadable(data, 64);
+    await expect(collectTransform(source, createDecompressTransform())).rejects.toThrow(
+      /unable to detect compression format/,
+    );
+  });
+
+  it('should handle single chunk', async () => {
+    const compressed = Buffer.from(gzipCompress(original));
+    const source = toChunkedReadable(compressed, compressed.length);
+    const result = await collectTransform(source, createDecompressTransform());
+    expect(Buffer.compare(result, original)).toBe(0);
+  });
+});

--- a/index.mjs
+++ b/index.mjs
@@ -55,4 +55,5 @@ export const {
   createGzipDecompressStream,
   createDeflateCompressStream,
   createDeflateDecompressStream,
+  createDecompressStream,
 } = streams;

--- a/node.d.ts
+++ b/node.d.ts
@@ -97,3 +97,12 @@ export declare function createZstdCompressDictTransform(
  * @param dict Pre-trained dictionary (must match the one used for compression).
  */
 export declare function createZstdDecompressDictTransform(dict: Buffer | Uint8Array): Transform;
+
+/**
+ * Create a Node.js stream.Transform for auto-detect decompression.
+ *
+ * Detects the compression format (zstd, gzip, or brotli) from the first
+ * few bytes and delegates to the appropriate decompression context.
+ * Raw deflate is not supported (no magic bytes to distinguish it).
+ */
+export declare function createDecompressTransform(): Transform;

--- a/node.js
+++ b/node.js
@@ -10,6 +10,7 @@ const {
   DeflateDecompressContext,
   BrotliCompressContext,
   BrotliDecompressContext,
+  detectFormat,
 } = require('./index.js');
 
 /**
@@ -323,6 +324,86 @@ function createZstdDecompressDictTransform(dict) {
   });
 }
 
+function createDecompressContext(format) {
+  switch (format) {
+    case 'zstd':
+      return new ZstdDecompressContext();
+    case 'gzip':
+      return new GzipDecompressContext();
+    case 'brotli':
+      return new BrotliDecompressContext();
+    default:
+      throw new Error('unable to detect compression format from stream data');
+  }
+}
+
+function pushIfNonEmpty(stream, result) {
+  if (result.byteLength > 0) stream.push(result);
+}
+
+/**
+ * Create a Node.js stream.Transform for auto-detect decompression.
+ *
+ * Detects the compression format (zstd, gzip, or brotli) from the first
+ * few bytes and delegates to the appropriate decompression context.
+ * Raw deflate is not supported (no magic bytes to distinguish it).
+ *
+ * @returns {Transform}
+ */
+function createDecompressTransform() {
+  let ctx = null;
+  let buffer = null;
+
+  function detectAndReplay(stream, data) {
+    ctx = createDecompressContext(detectFormat(data));
+    buffer = null;
+    pushIfNonEmpty(stream, ctx.transform(data));
+  }
+
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      try {
+        if (ctx) {
+          pushIfNonEmpty(this, ctx.transform(chunk));
+          callback();
+          return;
+        }
+
+        buffer = buffer === null ? Buffer.from(chunk) : Buffer.concat([buffer, chunk]);
+
+        if (buffer.length < 4) {
+          callback();
+          return;
+        }
+
+        detectAndReplay(this, buffer);
+        callback();
+      } catch (err) {
+        callback(err);
+      }
+    },
+    flush(callback) {
+      try {
+        if (!ctx && buffer && buffer.length > 0) {
+          detectAndReplay(this, buffer);
+        }
+        if (!ctx) {
+          callback();
+          return;
+        }
+
+        pushIfNonEmpty(this, ctx.flush());
+        if (ctx instanceof GzipDecompressContext) {
+          pushIfNonEmpty(this, ctx.finish());
+        }
+        callback();
+      } catch (err) {
+        callback(err);
+      }
+    },
+  });
+}
+
 module.exports = {
   createZstdCompressTransform,
   createZstdDecompressTransform,
@@ -334,4 +415,5 @@ module.exports = {
   createDeflateDecompressTransform,
   createBrotliCompressTransform,
   createBrotliDecompressTransform,
+  createDecompressTransform,
 };

--- a/streams.d.ts
+++ b/streams.d.ts
@@ -103,3 +103,12 @@ export declare function createZstdCompressDictStream(
 export declare function createZstdDecompressDictStream(
   dict: Buffer | Uint8Array,
 ): TransformStream<Uint8Array, Uint8Array>;
+
+/**
+ * Create a streaming auto-detect decompression TransformStream.
+ *
+ * Detects the compression format (zstd, gzip, or brotli) from the first
+ * few bytes and delegates to the appropriate decompression context.
+ * Raw deflate is not supported (no magic bytes to distinguish it).
+ */
+export declare function createDecompressStream(): TransformStream<Uint8Array, Uint8Array>;

--- a/streams.js
+++ b/streams.js
@@ -9,6 +9,7 @@ const {
   GzipDecompressContext,
   DeflateCompressContext,
   DeflateDecompressContext,
+  detectFormat,
 } = require('./index.js');
 
 /**
@@ -276,6 +277,78 @@ function createZstdDecompressDictStream(dict) {
   });
 }
 
+function createDecompressContext(format) {
+  switch (format) {
+    case 'zstd':
+      return new ZstdDecompressContext();
+    case 'gzip':
+      return new GzipDecompressContext();
+    case 'brotli':
+      return new BrotliDecompressContext();
+    default:
+      throw new Error('unable to detect compression format from stream data');
+  }
+}
+
+function enqueueIfNonEmpty(controller, result) {
+  if (result.byteLength > 0) {
+    controller.enqueue(new Uint8Array(result));
+  }
+}
+
+/**
+ * Create a streaming auto-detect decompression TransformStream.
+ *
+ * Detects the compression format (zstd, gzip, or brotli) from the first
+ * few bytes and delegates to the appropriate decompression context.
+ * Raw deflate is not supported (no magic bytes to distinguish it).
+ *
+ * @returns {TransformStream<Uint8Array, Uint8Array>}
+ */
+function createDecompressStream() {
+  let ctx = null;
+  let buffer = null;
+
+  function detectAndReplay(data, controller) {
+    ctx = createDecompressContext(detectFormat(data));
+    buffer = null;
+    enqueueIfNonEmpty(controller, ctx.transform(data));
+  }
+
+  return new TransformStream({
+    transform(chunk, controller) {
+      if (ctx) {
+        enqueueIfNonEmpty(controller, ctx.transform(chunk));
+        return;
+      }
+
+      if (buffer === null) {
+        buffer = new Uint8Array(chunk);
+      } else {
+        const combined = new Uint8Array(buffer.length + chunk.length);
+        combined.set(buffer);
+        combined.set(chunk, buffer.length);
+        buffer = combined;
+      }
+
+      if (buffer.length < 4) return;
+
+      detectAndReplay(buffer, controller);
+    },
+    flush(controller) {
+      if (!ctx && buffer && buffer.length > 0) {
+        detectAndReplay(buffer, controller);
+      }
+      if (!ctx) return;
+
+      enqueueIfNonEmpty(controller, ctx.flush());
+      if (ctx instanceof GzipDecompressContext) {
+        enqueueIfNonEmpty(controller, ctx.finish());
+      }
+    },
+  });
+}
+
 module.exports = {
   createBrotliCompressStream,
   createBrotliDecompressStream,
@@ -287,4 +360,5 @@ module.exports = {
   createGzipDecompressStream,
   createDeflateCompressStream,
   createDeflateDecompressStream,
+  createDecompressStream,
 };


### PR DESCRIPTION
## Summary

- Add `createDecompressStream()` (Web Streams API) that auto-detects compression format
- Add `createDecompressTransform()` (Node.js Transform) with same functionality
- Buffers initial bytes for format detection, then delegates to appropriate decompression context
- Supports zstd, gzip, and brotli (raw deflate not supported due to no magic bytes)

## Changes

- `streams.js`: `createDecompressStream()` with format detection and buffering logic
- `node.js`: `createDecompressTransform()` with equivalent Node.js Transform implementation
- `streams.d.ts` / `node.d.ts`: Type declarations
- `index.mjs`: ESM export for `createDecompressStream`
- `__test__/decompress-stream.spec.ts`: 12 tests covering all formats, buffering, and error cases

## Test plan

- [x] Round-trip tests for zstd, gzip, brotli through auto-detect stream
- [x] Small first-chunk buffering test (< 4 bytes)
- [x] Unknown format throws descriptive error
- [x] Node.js Transform variants pass all tests
- [x] All existing tests pass (333 passed)
- [x] Biome lint clean
- [x] TypeScript typecheck clean

Closes #127