### PR TITLE
chore: improve package.json metadata and exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "url": "git+https://github.com/derodero24/zflate.git"
   },
   "homepage": "https://github.com/derodero24/zflate",
+  "bugs": {
+    "url": "https://github.com/derodero24/zflate/issues"
+  },
   "keywords": [
     "compression",
     "zstd",
@@ -39,7 +42,10 @@
         "types": "./index.d.ts",
         "default": "./index.js"
       },
-      "browser": "./browser.js"
+      "browser": {
+        "types": "./index.d.ts",
+        "default": "./browser.js"
+      }
     },
     "./streams": {
       "import": {


### PR DESCRIPTION
## Summary

- Add `bugs` field to `package.json` for proper npm registry issue tracker linking
- Add `types` condition to the `browser` export in the exports map, ensuring TypeScript users get type resolution when importing via the browser condition

## Related issue

Closes #141

## Checklist

- [x] `bugs` field added after `homepage`
- [x] `browser` export condition updated with `types` and `default`
- [x] JSON validated with `node -e "require('./package.json')"`
- [x] `publint` passes with no new warnings
- [x] `cargo test` passes
- [x] `cargo clippy` passes