### PR TITLE
ci: clean up CI workflow configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ on:
       - 'index.d.mts'
       - 'node.js'
       - 'node.d.ts'
-      - 'e2e/**'
       - 'playwright.config.ts'
   pull_request:
     branches: [develop]
@@ -47,7 +46,6 @@ on:
       - 'index.d.mts'
       - 'node.js'
       - 'node.d.ts'
-      - 'e2e/**'
       - 'playwright.config.ts'
 
 concurrency:
@@ -98,7 +96,7 @@ jobs:
       - name: Audit Rust dependencies
         uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2
       - name: Install cargo-audit
-        uses: taiki-e/install-action@c12d62a803cbdfe2e7263af15f5a9548065cb4f2
+        uses: taiki-e/install-action@c12d62a803cbdfe2e7263af15f5a9548065cb4f2 # v2
         with:
           tool: cargo-audit
       - name: Run cargo audit
@@ -391,7 +389,7 @@ jobs:
           toolchain: stable
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - uses: taiki-e/install-action@c12d62a803cbdfe2e7263af15f5a9548065cb4f2
+      - uses: taiki-e/install-action@c12d62a803cbdfe2e7263af15f5a9548065cb4f2 # v2
         with:
           tool: cargo-llvm-cov
       - name: Rust coverage


### PR DESCRIPTION
## Summary

- Remove duplicate `e2e/**` path entries from both `push.paths` and `pull_request.paths` trigger arrays
- Add version tag comment (`# v2`) to `taiki-e/install-action` SHA references for consistency with all other pinned actions

Closes #138

## Checklist

- [x] Duplicate `e2e/**` entries removed (lines 26 and 50)
- [x] Version tag comments added to `taiki-e/install-action` (lines 98, 391)
- [x] No functional changes to CI behavior