### PR TITLE
ci(testing): add coverage thresholds to vitest

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -13,6 +13,12 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'lcov'],
       reportsDirectory: 'coverage',
+      include: ['streams.js', 'node.js'],
+      thresholds: {
+        lines: 70,
+        functions: 80,
+        branches: 60,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

- Add coverage thresholds to `vitest.config.mts` to prevent regression
- Scope coverage to hand-written JS files (`streams.js`, `node.js`), excluding napi-rs generated loader code (`index.js`, `browser.js`) and WASM loader (`zflate.wasi.cjs`) which have inherently low coverage due to platform-specific branching
- Thresholds: lines 70%, functions 80%, branches 60%

### Current coverage baseline

| File | Stmts | Branch | Funcs | Lines |
|------|-------|--------|-------|-------|
| node.js | 71.5% | 62.7% | 83.3% | 73.3% |
| streams.js | 92.6% | 72.0% | 100% | 93.2% |
| **All (scoped)** | **80.0%** | **67.3%** | **91.7%** | **82.0%** |

Closes #143

## Checklist

- [x] Current coverage baseline measured
- [x] Thresholds set below current baseline (headroom for normal variance)
- [x] Generated files excluded from threshold enforcement
- [x] `pnpm vitest run --coverage` passes locally