### PR TITLE
ci: add aggregate gate job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,3 +417,17 @@ jobs:
           files: rust-lcov.info,coverage/lcov.info
           flags: rust,javascript
           fail_ci_if_error: false
+
+  # ──── Aggregate gate: single required status check ────
+  ci-complete:
+    name: CI Complete
+    if: always()
+    needs: [lint, audit, rust-lint, rust-test, test, test-wasm, test-browser, test-deno, test-bun, coverage]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all jobs
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" || "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Add `ci-complete` aggregate gate job that depends on all CI jobs
- Enables using a single required status check (`CI Complete`) in branch protection instead of listing all 11 individual jobs
- Job fails if any dependency fails or is cancelled

### How it works

```yaml
ci-complete:
  name: CI Complete
  if: always()
  needs: [lint, audit, rust-lint, rust-test, test, test-wasm, test-browser, test-deno, test-bun, coverage]
```

### Benefits

- Adding/removing CI jobs no longer requires changes to branch protection settings
- Single source of truth for "CI passed"
- Follows the pattern used by swc and napi-rs projects

Closes #136

## Manual step required after merge

Update branch protection rules for `develop` to require only `CI Complete` instead of individual job names.

## Checklist

- [x] `ci-complete` job depends on all other CI jobs
- [x] Uses `if: always()` to run even when dependencies are skipped
- [x] Fails on any `failure` or `cancelled` dependency result

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他**
  * CI パイプラインの統合ゲート機能を追加し、すべてのテスト実行結果を一元管理することでビルドプロセスの信頼性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->