### PR TITLE
feat(streaming): add configurable maxOutputSize to decompression contexts

### DIFF
--- a/__test__/max-output-size.spec.ts
+++ b/__test__/max-output-size.spec.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BrotliDecompressContext,
+  brotliCompress,
+  DeflateDecompressContext,
+  deflateCompress,
+  GzipDecompressContext,
+  gzipCompress,
+  ZstdDecompressContext,
+  ZstdDecompressDictContext,
+  zstdCompress,
+  zstdCompressWithDict,
+  zstdTrainDictionary,
+} from '../index.js';
+import {
+  createBrotliDecompressStream,
+  createDecompressStream,
+  createDeflateDecompressStream,
+  createGzipDecompressStream,
+  createZstdDecompressDictStream,
+  createZstdDecompressStream,
+} from '../streams.js';
+
+/** Collect all chunks from a ReadableStream into a single Buffer. */
+async function collectStream(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
+  const chunks: Uint8Array[] = [];
+  const reader = stream.getReader();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks);
+}
+
+/** Fully decompress using a context (transform + finish/flush), returning all output. */
+function decompressAll(
+  ctx: { transform(chunk: Buffer): Buffer; finish?: () => Buffer; flush?: () => Buffer },
+  compressed: Buffer,
+): Buffer {
+  const chunks: Buffer[] = [];
+  chunks.push(ctx.transform(compressed));
+  if (ctx.flush) chunks.push(ctx.flush());
+  if (ctx.finish) chunks.push(ctx.finish());
+  return Buffer.concat(chunks);
+}
+
+// ---------------------------------------------------------------------------
+// Custom maxOutputSize enforcement on decompression contexts
+// ---------------------------------------------------------------------------
+
+describe('maxOutputSize on decompression contexts', () => {
+  // Use a large enough buffer that the decompressed output exceeds the limit.
+  // 4096 bytes of repeating data compresses very well.
+  const originalData = Buffer.alloc(4096, 0x42);
+
+  describe('GzipDecompressContext', () => {
+    const compressed = gzipCompress(originalData);
+
+    it('should enforce custom maxOutputSize', () => {
+      const ctx = new GzipDecompressContext(100);
+      // Gzip buffers internally; the error may occur in transform or finish
+      expect(() => decompressAll(ctx, compressed)).toThrow(/exceeded maximum size/);
+    });
+
+    it('should decompress normally when maxOutputSize is omitted', () => {
+      const ctx = new GzipDecompressContext();
+      const result = decompressAll(ctx, compressed);
+      expect(result.byteLength).toBe(4096);
+    });
+
+    it('should decompress normally when maxOutputSize is large enough', () => {
+      const ctx = new GzipDecompressContext(8192);
+      const result = decompressAll(ctx, compressed);
+      expect(result.byteLength).toBe(4096);
+    });
+  });
+
+  describe('DeflateDecompressContext', () => {
+    const compressed = deflateCompress(originalData);
+
+    it('should enforce custom maxOutputSize', () => {
+      const ctx = new DeflateDecompressContext(100);
+      expect(() => decompressAll(ctx, compressed)).toThrow(/exceeded maximum size/);
+    });
+
+    it('should decompress normally when maxOutputSize is omitted', () => {
+      const ctx = new DeflateDecompressContext();
+      const result = decompressAll(ctx, compressed);
+      expect(result.byteLength).toBe(4096);
+    });
+
+    it('should decompress normally when maxOutputSize is large enough', () => {
+      const ctx = new DeflateDecompressContext(8192);
+      const result = decompressAll(ctx, compressed);
+      expect(result.byteLength).toBe(4096);
+    });
+  });
+
+  describe('ZstdDecompressContext', () => {
+    const compressed = zstdCompress(originalData);
+
+    it('should enforce custom maxOutputSize', () => {
+      const ctx = new ZstdDecompressContext(100);
+      expect(() => ctx.transform(compressed)).toThrow(/exceeded maximum size/);
+    });
+
+    it('should decompress normally when maxOutputSize is omitted', () => {
+      const ctx = new ZstdDecompressContext();
+      const result = ctx.transform(compressed);
+      expect(result.byteLength).toBe(4096);
+    });
+
+    it('should decompress normally when maxOutputSize is large enough', () => {
+      const ctx = new ZstdDecompressContext(8192);
+      const result = ctx.transform(compressed);
+      expect(result.byteLength).toBe(4096);
+    });
+  });
+
+  describe('BrotliDecompressContext', () => {
+    const compressed = brotliCompress(originalData);
+
+    it('should enforce custom maxOutputSize', () => {
+      const ctx = new BrotliDecompressContext(100);
+      expect(() => decompressAll(ctx, compressed)).toThrow(/exceeded maximum size/);
+    });
+
+    it('should decompress normally when maxOutputSize is omitted', () => {
+      const ctx = new BrotliDecompressContext();
+      const result = decompressAll(ctx, compressed);
+      expect(result.byteLength).toBe(4096);
+    });
+
+    it('should decompress normally when maxOutputSize is large enough', () => {
+      const ctx = new BrotliDecompressContext(8192);
+      const result = decompressAll(ctx, compressed);
+      expect(result.byteLength).toBe(4096);
+    });
+  });
+
+  describe('ZstdDecompressDictContext', () => {
+    // Train a minimal dictionary from sample data
+    const samples = Array.from({ length: 10 }, (_, i) =>
+      Buffer.from(`sample data entry ${i} `.repeat(20)),
+    );
+    const dict = zstdTrainDictionary(samples, 4096);
+    const testData = Buffer.from('sample data entry 0 '.repeat(200));
+    const compressed = zstdCompressWithDict(testData, dict);
+
+    it('should enforce custom maxOutputSize', () => {
+      const ctx = new ZstdDecompressDictContext(dict, 100);
+      expect(() => ctx.transform(compressed)).toThrow(/exceeded maximum size/);
+    });
+
+    it('should decompress normally when maxOutputSize is omitted', () => {
+      const ctx = new ZstdDecompressDictContext(dict);
+      const result = ctx.transform(compressed);
+      expect(result.byteLength).toBe(testData.byteLength);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation of invalid maxOutputSize values
+// ---------------------------------------------------------------------------
+
+describe('maxOutputSize validation', () => {
+  it('should throw for NaN', () => {
+    expect(() => new GzipDecompressContext(Number.NaN)).toThrow(
+      /maxOutputSize must be a positive finite number/,
+    );
+  });
+
+  it('should throw for Infinity', () => {
+    expect(() => new GzipDecompressContext(Number.POSITIVE_INFINITY)).toThrow(
+      /maxOutputSize must be a positive finite number/,
+    );
+  });
+
+  it('should throw for negative Infinity', () => {
+    expect(() => new GzipDecompressContext(Number.NEGATIVE_INFINITY)).toThrow(
+      /maxOutputSize must be a positive finite number/,
+    );
+  });
+
+  it('should throw for negative values', () => {
+    expect(() => new GzipDecompressContext(-1)).toThrow(
+      /maxOutputSize must be a positive finite number/,
+    );
+  });
+
+  it('should accept zero as maxOutputSize', () => {
+    // Zero means "no output allowed" — valid edge case
+    const ctx = new GzipDecompressContext(0);
+    const compressed = gzipCompress(Buffer.alloc(1024, 0x42));
+    expect(() => decompressAll(ctx, compressed)).toThrow(/exceeded maximum size/);
+  });
+
+  it('should validate on all context types', () => {
+    expect(() => new DeflateDecompressContext(Number.NaN)).toThrow(
+      /maxOutputSize must be a positive finite number/,
+    );
+    expect(() => new ZstdDecompressContext(Number.NaN)).toThrow(
+      /maxOutputSize must be a positive finite number/,
+    );
+    expect(() => new BrotliDecompressContext(Number.NaN)).toThrow(
+      /maxOutputSize must be a positive finite number/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Streaming factory functions pass through maxOutputSize
+// ---------------------------------------------------------------------------
+
+describe('streaming factory functions with maxOutputSize', () => {
+  const originalData = Buffer.alloc(4096, 0x42);
+
+  it('should enforce maxOutputSize on createGzipDecompressStream', async () => {
+    const compressed = gzipCompress(originalData);
+    const input = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(compressed));
+        controller.close();
+      },
+    });
+    await expect(collectStream(input.pipeThrough(createGzipDecompressStream(100)))).rejects.toThrow(
+      /exceeded maximum size/,
+    );
+  });
+
+  it('should enforce maxOutputSize on createDeflateDecompressStream', async () => {
+    const compressed = deflateCompress(originalData);
+    const input = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(compressed));
+        controller.close();
+      },
+    });
+    await expect(
+      collectStream(input.pipeThrough(createDeflateDecompressStream(100))),
+    ).rejects.toThrow(/exceeded maximum size/);
+  });
+
+  it('should enforce maxOutputSize on createZstdDecompressStream', async () => {
+    const compressed = zstdCompress(originalData);
+    const input = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(compressed));
+        controller.close();
+      },
+    });
+    await expect(collectStream(input.pipeThrough(createZstdDecompressStream(100)))).rejects.toThrow(
+      /exceeded maximum size/,
+    );
+  });
+
+  it('should enforce maxOutputSize on createBrotliDecompressStream', async () => {
+    const compressed = brotliCompress(originalData);
+    const input = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(compressed));
+        controller.close();
+      },
+    });
+    await expect(
+      collectStream(input.pipeThrough(createBrotliDecompressStream(100))),
+    ).rejects.toThrow(/exceeded maximum size/);
+  });
+
+  it('should enforce maxOutputSize on createDecompressStream (gzip)', async () => {
+    const compressed = gzipCompress(originalData);
+    const input = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(compressed));
+        controller.close();
+      },
+    });
+    await expect(collectStream(input.pipeThrough(createDecompressStream(100)))).rejects.toThrow(
+      /exceeded maximum size/,
+    );
+  });
+
+  it('should enforce maxOutputSize on createZstdDecompressDictStream', async () => {
+    const samples = Array.from({ length: 10 }, (_, i) =>
+      Buffer.from(`sample data entry ${i} `.repeat(20)),
+    );
+    const dict = zstdTrainDictionary(samples, 4096);
+    const testData = Buffer.from('sample data entry 0 '.repeat(200));
+    const compressed = zstdCompressWithDict(testData, dict);
+
+    const input = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(compressed));
+        controller.close();
+      },
+    });
+    await expect(
+      collectStream(input.pipeThrough(createZstdDecompressDictStream(dict, 100))),
+    ).rejects.toThrow(/exceeded maximum size/);
+  });
+});

--- a/crates/core/src/brotli_stream.rs
+++ b/crates/core/src/brotli_stream.rs
@@ -13,9 +13,6 @@ const DEFAULT_QUALITY: u32 = 6;
 /// Default buffer size for brotli operations.
 const BUFFER_SIZE: usize = 4096;
 
-/// Maximum allowed decompressed size (256 MB) to prevent memory exhaustion.
-const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
-
 /// Default log2 of the sliding window size for brotli.
 const LG_WINDOW_SIZE: u32 = 22;
 
@@ -110,16 +107,19 @@ impl BrotliCompressContext {
 pub struct BrotliDecompressContext {
     decompressor: brotli::DecompressorWriter<Vec<u8>>,
     total_output: usize,
+    max_output_size: usize,
 }
 
 #[napi]
 impl BrotliDecompressContext {
     #[napi(constructor)]
-    pub fn new() -> Result<Self> {
+    pub fn new(max_output_size: Option<f64>) -> Result<Self> {
+        let max_size = crate::validate_max_output_size(max_output_size)?;
         let decompressor = brotli::DecompressorWriter::new(Vec::new(), BUFFER_SIZE);
         Ok(Self {
             decompressor,
             total_output: 0,
+            max_output_size: max_size,
         })
     }
 
@@ -139,10 +139,10 @@ impl BrotliDecompressContext {
         // Drain whatever the decompressor has written to the inner Vec
         let data = std::mem::take(self.decompressor.get_mut());
         self.total_output += data.len();
-        if self.total_output > MAX_DECOMPRESSED_SIZE {
+        if self.total_output > self.max_output_size {
             return Err(ZflateError::SizeLimit {
                 context: "brotli stream decompress",
-                limit: MAX_DECOMPRESSED_SIZE,
+                limit: self.max_output_size,
             }
             .into());
         }
@@ -160,6 +160,14 @@ impl BrotliDecompressContext {
         })?;
 
         let data = std::mem::take(self.decompressor.get_mut());
+        self.total_output += data.len();
+        if self.total_output > self.max_output_size {
+            return Err(ZflateError::SizeLimit {
+                context: "brotli stream decompress",
+                limit: self.max_output_size,
+            }
+            .into());
+        }
         Ok(data.into())
     }
 }

--- a/crates/core/src/gzip_stream.rs
+++ b/crates/core/src/gzip_stream.rs
@@ -12,9 +12,6 @@ use crate::ZflateError;
 /// Default compression level for gzip/deflate (same as zlib default).
 const DEFAULT_LEVEL: u32 = 6;
 
-/// Maximum allowed decompressed size (256 MB) to prevent memory exhaustion.
-const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
-
 /// Streaming gzip compression context.
 ///
 /// Maintains internal compression state across multiple `transform` calls,
@@ -108,16 +105,19 @@ impl GzipCompressContext {
 pub struct GzipDecompressContext {
     decoder: Option<MultiGzDecoder<Vec<u8>>>,
     total_output: usize,
+    max_output_size: usize,
 }
 
 #[napi]
 impl GzipDecompressContext {
     #[napi(constructor)]
-    pub fn new() -> Result<Self> {
+    pub fn new(max_output_size: Option<f64>) -> Result<Self> {
+        let max_size = crate::validate_max_output_size(max_output_size)?;
         let decoder = MultiGzDecoder::new(Vec::new());
         Ok(Self {
             decoder: Some(decoder),
             total_output: 0,
+            max_output_size: max_size,
         })
     }
 
@@ -148,10 +148,10 @@ impl GzipDecompressContext {
         let output = decoder.get_mut();
         let data = std::mem::take(output);
         self.total_output += data.len();
-        if self.total_output > MAX_DECOMPRESSED_SIZE {
+        if self.total_output > self.max_output_size {
             return Err(ZflateError::SizeLimit {
                 context: "gzip stream decompress",
-                limit: MAX_DECOMPRESSED_SIZE,
+                limit: self.max_output_size,
             }
             .into());
         }
@@ -175,6 +175,14 @@ impl GzipDecompressContext {
 
         let output = decoder.get_mut();
         let data = std::mem::take(output);
+        self.total_output += data.len();
+        if self.total_output > self.max_output_size {
+            return Err(ZflateError::SizeLimit {
+                context: "gzip stream decompress",
+                limit: self.max_output_size,
+            }
+            .into());
+        }
         Ok(data.into())
     }
 
@@ -289,16 +297,19 @@ impl DeflateCompressContext {
 pub struct DeflateDecompressContext {
     decoder: Option<DeflateDecoder<Vec<u8>>>,
     total_output: usize,
+    max_output_size: usize,
 }
 
 #[napi]
 impl DeflateDecompressContext {
     #[napi(constructor)]
-    pub fn new() -> Result<Self> {
+    pub fn new(max_output_size: Option<f64>) -> Result<Self> {
+        let max_size = crate::validate_max_output_size(max_output_size)?;
         let decoder = DeflateDecoder::new(Vec::new());
         Ok(Self {
             decoder: Some(decoder),
             total_output: 0,
+            max_output_size: max_size,
         })
     }
 
@@ -321,10 +332,10 @@ impl DeflateDecompressContext {
         let output = decoder.get_mut();
         let data = std::mem::take(output);
         self.total_output += data.len();
-        if self.total_output > MAX_DECOMPRESSED_SIZE {
+        if self.total_output > self.max_output_size {
             return Err(ZflateError::SizeLimit {
                 context: "deflate stream decompress",
-                limit: MAX_DECOMPRESSED_SIZE,
+                limit: self.max_output_size,
             }
             .into());
         }
@@ -348,6 +359,14 @@ impl DeflateDecompressContext {
 
         let output = decoder.get_mut();
         let data = std::mem::take(output);
+        self.total_output += data.len();
+        if self.total_output > self.max_output_size {
+            return Err(ZflateError::SizeLimit {
+                context: "deflate stream decompress",
+                limit: self.max_output_size,
+            }
+            .into());
+        }
         Ok(data.into())
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,11 +14,31 @@ use napi_derive::napi;
 
 pub use error::ZflateError;
 
+/// Maximum allowed decompressed size (256 MB) to prevent memory exhaustion.
+const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
+
 /// Extract byte slice from Either<Buffer, Uint8Array>.
 fn as_bytes(data: &Either<Buffer, Uint8Array>) -> &[u8] {
     match data {
         Either::A(buf) => buf.as_ref(),
         Either::B(arr) => arr.as_ref(),
+    }
+}
+
+/// Validate and return the max output size, defaulting to MAX_DECOMPRESSED_SIZE.
+fn validate_max_output_size(max_output_size: Option<f64>) -> Result<usize> {
+    match max_output_size {
+        None => Ok(MAX_DECOMPRESSED_SIZE),
+        Some(size) => {
+            if !size.is_finite() || size < 0.0 {
+                Err(ZflateError::InvalidArg(
+                    "maxOutputSize must be a positive finite number".to_string(),
+                )
+                .into())
+            } else {
+                Ok(size as usize)
+            }
+        }
     }
 }
 

--- a/crates/core/src/zstd_stream.rs
+++ b/crates/core/src/zstd_stream.rs
@@ -12,9 +12,6 @@ const DEFAULT_LEVEL: i32 = 3;
 /// Initial output buffer size for streaming operations.
 const INITIAL_BUF_SIZE: usize = 128 * 1024;
 
-/// Maximum allowed decompressed size (256 MB) to prevent memory exhaustion.
-const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
-
 /// Streaming zstd compression context.
 ///
 /// Maintains internal compression state across multiple `transform` calls,
@@ -154,12 +151,14 @@ impl ZstdCompressContext {
 pub struct ZstdDecompressContext {
     decoder: Decoder<'static>,
     total_output: usize,
+    max_output_size: usize,
 }
 
 #[napi]
 impl ZstdDecompressContext {
     #[napi(constructor)]
-    pub fn new() -> Result<Self> {
+    pub fn new(max_output_size: Option<f64>) -> Result<Self> {
+        let max_size = crate::validate_max_output_size(max_output_size)?;
         let decoder = Decoder::new().map_err(|e| {
             napi::Error::from(ZflateError::Creation {
                 context: "zstd decoder",
@@ -169,6 +168,7 @@ impl ZstdDecompressContext {
         Ok(Self {
             decoder,
             total_output: 0,
+            max_output_size: max_size,
         })
     }
 
@@ -192,10 +192,10 @@ impl ZstdDecompressContext {
                 })
             })?;
             total_written = out_buf.pos();
-            if self.total_output + total_written > MAX_DECOMPRESSED_SIZE {
+            if self.total_output + total_written > self.max_output_size {
                 return Err(ZflateError::SizeLimit {
                     context: "zstd stream decompress",
-                    limit: MAX_DECOMPRESSED_SIZE,
+                    limit: self.max_output_size,
                 }
                 .into());
             }
@@ -377,12 +377,14 @@ impl ZstdCompressDictContext {
 pub struct ZstdDecompressDictContext {
     decoder: Decoder<'static>,
     total_output: usize,
+    max_output_size: usize,
 }
 
 #[napi]
 impl ZstdDecompressDictContext {
     #[napi(constructor)]
-    pub fn new(dict: Either<Buffer, Uint8Array>) -> Result<Self> {
+    pub fn new(dict: Either<Buffer, Uint8Array>, max_output_size: Option<f64>) -> Result<Self> {
+        let max_size = crate::validate_max_output_size(max_output_size)?;
         let dict_bytes = crate::as_bytes(&dict);
         let decoder = Decoder::with_dictionary(dict_bytes).map_err(|e| {
             napi::Error::from(ZflateError::Creation {
@@ -393,6 +395,7 @@ impl ZstdDecompressDictContext {
         Ok(Self {
             decoder,
             total_output: 0,
+            max_output_size: max_size,
         })
     }
 
@@ -416,10 +419,10 @@ impl ZstdDecompressDictContext {
                 })
             })?;
             total_written = out_buf.pos();
-            if self.total_output + total_written > MAX_DECOMPRESSED_SIZE {
+            if self.total_output + total_written > self.max_output_size {
                 return Err(ZflateError::SizeLimit {
                     context: "zstd stream decompress",
-                    limit: MAX_DECOMPRESSED_SIZE,
+                    limit: self.max_output_size,
                 }
                 .into());
             }

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ export declare class BrotliCompressContext {
  * enabling chunked decompression of a brotli stream.
  */
 export declare class BrotliDecompressContext {
-  constructor()
+  constructor(maxOutputSize?: number | undefined | null)
   /**
    * Decompress a chunk of compressed data. Returns decompressed output
    * (may be empty if the decompressor needs more data).
@@ -68,7 +68,7 @@ export declare class DeflateCompressContext {
  * enabling chunked decompression of a raw deflate stream.
  */
 export declare class DeflateDecompressContext {
-  constructor()
+  constructor(maxOutputSize?: number | undefined | null)
   /**
    * Decompress a chunk of compressed data. Returns decompressed output
    * (may be empty if the decoder needs more data).
@@ -112,7 +112,7 @@ export declare class GzipCompressContext {
  * enabling chunked decompression of a gzip stream.
  */
 export declare class GzipDecompressContext {
-  constructor()
+  constructor(maxOutputSize?: number | undefined | null)
   /**
    * Decompress a chunk of compressed data. Returns decompressed output
    * (may be empty if the decoder needs more data).
@@ -178,7 +178,7 @@ export declare class ZstdCompressDictContext {
  * enabling chunked decompression of a zstd frame.
  */
 export declare class ZstdDecompressContext {
-  constructor()
+  constructor(maxOutputSize?: number | undefined | null)
   /**
    * Decompress a chunk of compressed data. Returns decompressed output
    * (may be empty if the decoder needs more data).
@@ -195,7 +195,7 @@ export declare class ZstdDecompressContext {
  * using a pre-trained dictionary that matches the one used for compression.
  */
 export declare class ZstdDecompressDictContext {
-  constructor(dict: Buffer | Uint8Array)
+  constructor(dict: Buffer | Uint8Array, maxOutputSize?: number | undefined | null)
   /**
    * Decompress a chunk of compressed data. Returns decompressed output
    * (may be empty if the decoder needs more data).

--- a/node.d.ts
+++ b/node.d.ts
@@ -15,8 +15,10 @@ export declare function createZstdCompressTransform(level?: number): Transform;
  *
  * Uses Node.js `stream.Transform` to provide chunked decompression compatible
  * with `stream.pipeline()` and pipe-based workflows.
+ *
+ * @param maxOutputSize Maximum decompressed output size in bytes. Default is 256 MB.
  */
-export declare function createZstdDecompressTransform(): Transform;
+export declare function createZstdDecompressTransform(maxOutputSize?: number): Transform;
 
 /**
  * Create a Node.js stream.Transform for gzip compression.
@@ -35,8 +37,10 @@ export declare function createGzipCompressTransform(level?: number): Transform;
  * Uses Node.js `stream.Transform` to provide chunked gzip decompression compatible
  * with `stream.pipeline()` and pipe-based workflows.
  * Verifies CRC32 integrity on finalization.
+ *
+ * @param maxOutputSize Maximum decompressed output size in bytes. Default is 256 MB.
  */
-export declare function createGzipDecompressTransform(): Transform;
+export declare function createGzipDecompressTransform(maxOutputSize?: number): Transform;
 
 /**
  * Create a Node.js stream.Transform for raw deflate compression.
@@ -53,8 +57,10 @@ export declare function createDeflateCompressTransform(level?: number): Transfor
  *
  * Uses Node.js `stream.Transform` to provide chunked raw deflate decompression
  * compatible with `stream.pipeline()` and pipe-based workflows.
+ *
+ * @param maxOutputSize Maximum decompressed output size in bytes. Default is 256 MB.
  */
-export declare function createDeflateDecompressTransform(): Transform;
+export declare function createDeflateDecompressTransform(maxOutputSize?: number): Transform;
 
 /**
  * Create a Node.js stream.Transform for brotli compression.
@@ -71,8 +77,10 @@ export declare function createBrotliCompressTransform(quality?: number): Transfo
  *
  * Uses Node.js `stream.Transform` to provide chunked brotli decompression compatible
  * with `stream.pipeline()` and pipe-based workflows.
+ *
+ * @param maxOutputSize Maximum decompressed output size in bytes. Default is 256 MB.
  */
-export declare function createBrotliDecompressTransform(): Transform;
+export declare function createBrotliDecompressTransform(maxOutputSize?: number): Transform;
 
 /**
  * Create a Node.js stream.Transform for zstd compression with a pre-trained dictionary.
@@ -96,7 +104,10 @@ export declare function createZstdCompressDictTransform(
  *
  * @param dict Pre-trained dictionary (must match the one used for compression).
  */
-export declare function createZstdDecompressDictTransform(dict: Buffer | Uint8Array): Transform;
+export declare function createZstdDecompressDictTransform(
+  dict: Buffer | Uint8Array,
+  maxOutputSize?: number,
+): Transform;
 
 /**
  * Create a Node.js stream.Transform for auto-detect decompression.
@@ -104,5 +115,7 @@ export declare function createZstdDecompressDictTransform(dict: Buffer | Uint8Ar
  * Detects the compression format (zstd, gzip, or brotli) from the first
  * few bytes and delegates to the appropriate decompression context.
  * Raw deflate is not supported (no magic bytes to distinguish it).
+ *
+ * @param maxOutputSize Maximum decompressed output size in bytes. Default is 256 MB.
  */
-export declare function createDecompressTransform(): Transform;
+export declare function createDecompressTransform(maxOutputSize?: number): Transform;

--- a/node.js
+++ b/node.js
@@ -48,10 +48,11 @@ function createZstdCompressTransform(level) {
 /**
  * Create a Node.js stream.Transform for zstd decompression.
  *
+ * @param {number} [maxOutputSize] Maximum decompressed output size in bytes
  * @returns {Transform}
  */
-function createZstdDecompressTransform() {
-  const ctx = new ZstdDecompressContext();
+function createZstdDecompressTransform(maxOutputSize) {
+  const ctx = new ZstdDecompressContext(maxOutputSize);
   return new Transform({
     transform(chunk, _encoding, callback) {
       try {
@@ -109,10 +110,11 @@ function createGzipCompressTransform(level) {
 /**
  * Create a Node.js stream.Transform for gzip decompression.
  *
+ * @param {number} [maxOutputSize] Maximum decompressed output size in bytes
  * @returns {Transform}
  */
-function createGzipDecompressTransform() {
-  const ctx = new GzipDecompressContext();
+function createGzipDecompressTransform(maxOutputSize) {
+  const ctx = new GzipDecompressContext(maxOutputSize);
   return new Transform({
     transform(chunk, _encoding, callback) {
       try {
@@ -172,10 +174,11 @@ function createDeflateCompressTransform(level) {
 /**
  * Create a Node.js stream.Transform for raw deflate decompression.
  *
+ * @param {number} [maxOutputSize] Maximum decompressed output size in bytes
  * @returns {Transform}
  */
-function createDeflateDecompressTransform() {
-  const ctx = new DeflateDecompressContext();
+function createDeflateDecompressTransform(maxOutputSize) {
+  const ctx = new DeflateDecompressContext(maxOutputSize);
   return new Transform({
     transform(chunk, _encoding, callback) {
       try {
@@ -235,10 +238,11 @@ function createBrotliCompressTransform(quality) {
 /**
  * Create a Node.js stream.Transform for brotli decompression.
  *
+ * @param {number} [maxOutputSize] Maximum decompressed output size in bytes
  * @returns {Transform}
  */
-function createBrotliDecompressTransform() {
-  const ctx = new BrotliDecompressContext();
+function createBrotliDecompressTransform(maxOutputSize) {
+  const ctx = new BrotliDecompressContext(maxOutputSize);
   return new Transform({
     transform(chunk, _encoding, callback) {
       try {
@@ -298,10 +302,11 @@ function createZstdCompressDictTransform(dict, level) {
  * Create a Node.js stream.Transform for zstd decompression with a pre-trained dictionary.
  *
  * @param {Buffer | Uint8Array} dict Pre-trained dictionary (must match the one used for compression)
+ * @param {number} [maxOutputSize] Maximum decompressed output size in bytes
  * @returns {Transform}
  */
-function createZstdDecompressDictTransform(dict) {
-  const ctx = new ZstdDecompressDictContext(dict);
+function createZstdDecompressDictTransform(dict, maxOutputSize) {
+  const ctx = new ZstdDecompressDictContext(dict, maxOutputSize);
   return new Transform({
     transform(chunk, _encoding, callback) {
       try {
@@ -324,14 +329,14 @@ function createZstdDecompressDictTransform(dict) {
   });
 }
 
-function createDecompressContext(format) {
+function createDecompressContext(format, maxOutputSize) {
   switch (format) {
     case 'zstd':
-      return new ZstdDecompressContext();
+      return new ZstdDecompressContext(maxOutputSize);
     case 'gzip':
-      return new GzipDecompressContext();
+      return new GzipDecompressContext(maxOutputSize);
     case 'brotli':
-      return new BrotliDecompressContext();
+      return new BrotliDecompressContext(maxOutputSize);
     default:
       throw new Error('unable to detect compression format from stream data');
   }
@@ -348,14 +353,15 @@ function pushIfNonEmpty(stream, result) {
  * few bytes and delegates to the appropriate decompression context.
  * Raw deflate is not supported (no magic bytes to distinguish it).
  *
+ * @param {number} [maxOutputSize] Maximum decompressed output size in bytes
  * @returns {Transform}
  */
-function createDecompressTransform() {
+function createDecompressTransform(maxOutputSize) {
   let ctx = null;
   let buffer = null;
 
   function detectAndReplay(stream, data) {
-    ctx = createDecompressContext(detectFormat(data));
+    ctx = createDecompressContext(detectFormat(data), maxOutputSize);
     buffer = null;
     pushIfNonEmpty(stream, ctx.transform(data));
   }

--- a/streams.d.ts
+++ b/streams.d.ts
@@ -15,8 +15,12 @@ export declare function createBrotliCompressStream(
  * Create a streaming brotli decompression TransformStream.
  *
  * Uses the Web Streams API (`TransformStream`) to provide chunked decompression.
+ *
+ * @param maxOutputSize Maximum decompressed output size in bytes. Default is 256 MB.
  */
-export declare function createBrotliDecompressStream(): TransformStream<Uint8Array, Uint8Array>;
+export declare function createBrotliDecompressStream(
+  maxOutputSize?: number,
+): TransformStream<Uint8Array, Uint8Array>;
 
 /**
  * Create a streaming zstd compression TransformStream.
@@ -35,8 +39,12 @@ export declare function createZstdCompressStream(
  * Create a streaming zstd decompression TransformStream.
  *
  * Uses the Web Streams API (`TransformStream`) to provide chunked decompression.
+ *
+ * @param maxOutputSize Maximum decompressed output size in bytes. Default is 256 MB.
  */
-export declare function createZstdDecompressStream(): TransformStream<Uint8Array, Uint8Array>;
+export declare function createZstdDecompressStream(
+  maxOutputSize?: number,
+): TransformStream<Uint8Array, Uint8Array>;
 
 /**
  * Create a streaming gzip compression TransformStream.
@@ -55,8 +63,12 @@ export declare function createGzipCompressStream(
  *
  * Uses the Web Streams API (`TransformStream`) to provide chunked gzip decompression.
  * Verifies CRC32 integrity on finalization.
+ *
+ * @param maxOutputSize Maximum decompressed output size in bytes. Default is 256 MB.
  */
-export declare function createGzipDecompressStream(): TransformStream<Uint8Array, Uint8Array>;
+export declare function createGzipDecompressStream(
+  maxOutputSize?: number,
+): TransformStream<Uint8Array, Uint8Array>;
 
 /**
  * Create a streaming raw deflate compression TransformStream.
@@ -75,8 +87,12 @@ export declare function createDeflateCompressStream(
  *
  * Uses the Web Streams API (`TransformStream`) to provide chunked raw deflate
  * decompression.
+ *
+ * @param maxOutputSize Maximum decompressed output size in bytes. Default is 256 MB.
  */
-export declare function createDeflateDecompressStream(): TransformStream<Uint8Array, Uint8Array>;
+export declare function createDeflateDecompressStream(
+  maxOutputSize?: number,
+): TransformStream<Uint8Array, Uint8Array>;
 
 /**
  * Create a streaming zstd compression TransformStream with a pre-trained dictionary.
@@ -99,9 +115,11 @@ export declare function createZstdCompressDictStream(
  * with a pre-trained dictionary. The same dictionary used for compression must be provided.
  *
  * @param dict Pre-trained dictionary (must match the one used for compression).
+ * @param maxOutputSize Maximum decompressed output size in bytes. Default is 256 MB.
  */
 export declare function createZstdDecompressDictStream(
   dict: Buffer | Uint8Array,
+  maxOutputSize?: number,
 ): TransformStream<Uint8Array, Uint8Array>;
 
 /**
@@ -110,5 +128,9 @@ export declare function createZstdDecompressDictStream(
  * Detects the compression format (zstd, gzip, or brotli) from the first
  * few bytes and delegates to the appropriate decompression context.
  * Raw deflate is not supported (no magic bytes to distinguish it).
+ *
+ * @param maxOutputSize Maximum decompressed output size in bytes. Default is 256 MB.
  */
-export declare function createDecompressStream(): TransformStream<Uint8Array, Uint8Array>;
+export declare function createDecompressStream(
+  maxOutputSize?: number,
+): TransformStream<Uint8Array, Uint8Array>;

--- a/streams.js
+++ b/streams.js
@@ -43,10 +43,11 @@ function createBrotliCompressStream(quality) {
 /**
  * Create a streaming brotli decompression TransformStream.
  *
+ * @param {number} [maxOutputSize] Maximum decompressed output size in bytes
  * @returns {TransformStream<Uint8Array, Uint8Array>}
  */
-function createBrotliDecompressStream() {
-  const ctx = new BrotliDecompressContext();
+function createBrotliDecompressStream(maxOutputSize) {
+  const ctx = new BrotliDecompressContext(maxOutputSize);
   return new TransformStream({
     transform(chunk, controller) {
       const result = ctx.transform(chunk);
@@ -94,10 +95,11 @@ function createZstdCompressStream(level) {
 /**
  * Create a streaming zstd decompression TransformStream.
  *
+ * @param {number} [maxOutputSize] Maximum decompressed output size in bytes
  * @returns {TransformStream<Uint8Array, Uint8Array>}
  */
-function createZstdDecompressStream() {
-  const ctx = new ZstdDecompressContext();
+function createZstdDecompressStream(maxOutputSize) {
+  const ctx = new ZstdDecompressContext(maxOutputSize);
   return new TransformStream({
     transform(chunk, controller) {
       const result = ctx.transform(chunk);
@@ -145,10 +147,11 @@ function createGzipCompressStream(level) {
 /**
  * Create a streaming gzip decompression TransformStream.
  *
+ * @param {number} [maxOutputSize] Maximum decompressed output size in bytes
  * @returns {TransformStream<Uint8Array, Uint8Array>}
  */
-function createGzipDecompressStream() {
-  const ctx = new GzipDecompressContext();
+function createGzipDecompressStream(maxOutputSize) {
+  const ctx = new GzipDecompressContext(maxOutputSize);
   return new TransformStream({
     transform(chunk, controller) {
       const result = ctx.transform(chunk);
@@ -200,10 +203,11 @@ function createDeflateCompressStream(level) {
 /**
  * Create a streaming raw deflate decompression TransformStream.
  *
+ * @param {number} [maxOutputSize] Maximum decompressed output size in bytes
  * @returns {TransformStream<Uint8Array, Uint8Array>}
  */
-function createDeflateDecompressStream() {
-  const ctx = new DeflateDecompressContext();
+function createDeflateDecompressStream(maxOutputSize) {
+  const ctx = new DeflateDecompressContext(maxOutputSize);
   return new TransformStream({
     transform(chunk, controller) {
       const result = ctx.transform(chunk);
@@ -257,10 +261,11 @@ function createZstdCompressDictStream(dict, level) {
  * Create a streaming zstd decompression TransformStream with a pre-trained dictionary.
  *
  * @param {Buffer | Uint8Array} dict Pre-trained dictionary (must match the one used for compression)
+ * @param {number} [maxOutputSize] Maximum decompressed output size in bytes
  * @returns {TransformStream<Uint8Array, Uint8Array>}
  */
-function createZstdDecompressDictStream(dict) {
-  const ctx = new ZstdDecompressDictContext(dict);
+function createZstdDecompressDictStream(dict, maxOutputSize) {
+  const ctx = new ZstdDecompressDictContext(dict, maxOutputSize);
   return new TransformStream({
     transform(chunk, controller) {
       const result = ctx.transform(chunk);
@@ -277,14 +282,14 @@ function createZstdDecompressDictStream(dict) {
   });
 }
 
-function createDecompressContext(format) {
+function createDecompressContext(format, maxOutputSize) {
   switch (format) {
     case 'zstd':
-      return new ZstdDecompressContext();
+      return new ZstdDecompressContext(maxOutputSize);
     case 'gzip':
-      return new GzipDecompressContext();
+      return new GzipDecompressContext(maxOutputSize);
     case 'brotli':
-      return new BrotliDecompressContext();
+      return new BrotliDecompressContext(maxOutputSize);
     default:
       throw new Error('unable to detect compression format from stream data');
   }
@@ -303,14 +308,15 @@ function enqueueIfNonEmpty(controller, result) {
  * few bytes and delegates to the appropriate decompression context.
  * Raw deflate is not supported (no magic bytes to distinguish it).
  *
+ * @param {number} [maxOutputSize] Maximum decompressed output size in bytes
  * @returns {TransformStream<Uint8Array, Uint8Array>}
  */
-function createDecompressStream() {
+function createDecompressStream(maxOutputSize) {
   let ctx = null;
   let buffer = null;
 
   function detectAndReplay(data, controller) {
-    ctx = createDecompressContext(detectFormat(data));
+    ctx = createDecompressContext(detectFormat(data), maxOutputSize);
     buffer = null;
     enqueueIfNonEmpty(controller, ctx.transform(data));
   }


### PR DESCRIPTION
## Summary

- Add optional `maxOutputSize` parameter to all streaming decompression context constructors
- When not specified, defaults to existing 256 MB limit (backward-compatible)
- Validation rejects NaN, Infinity, and negative values
- All streaming factory functions (`createXxxDecompressStream`, `createXxxDecompressTransform`) pass through the parameter

## Changes

### Rust
- `gzip_stream.rs`: `GzipDecompressContext(maxOutputSize?)`, `DeflateDecompressContext(maxOutputSize?)`
- `zstd_stream.rs`: `ZstdDecompressContext(maxOutputSize?)`, `ZstdDecompressDictContext(dict, maxOutputSize?)`
- `brotli_stream.rs`: `BrotliDecompressContext(maxOutputSize?)`
- `lib.rs`: Shared `validate_max_output_size()` helper and `MAX_DECOMPRESSED_SIZE` constant

### JS
- `streams.js` / `node.js`: All decompression factory functions accept `maxOutputSize`
- `streams.d.ts` / `node.d.ts`: Updated type declarations

### Tests
- `__test__/max-output-size.spec.ts`: 26 tests covering enforcement, defaults, validation, and streaming pass-through

## Test plan

- [x] Rust tests pass
- [x] JS tests pass (26 new tests)
- [x] cargo clippy clean
- [x] Biome lint clean
- [x] TypeScript typecheck clean
- [x] Default 256 MB limit preserved when parameter omitted
- [x] Custom smaller limits correctly enforced
- [x] Validation rejects invalid values

Closes #129