### PR TITLE
ci: add environment protection for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,10 +208,11 @@ jobs:
     name: Publish
     needs: [check, build]
     if: needs.check.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    environment: npm-publish
     permissions:
       contents: read
       id-token: write
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5


### PR DESCRIPTION
## Summary

- Add `environment: npm-publish` to the `publish` job in the release workflow
- Reorder job keys so `runs-on` appears before `permissions` for consistency with the desired layout

## Setup Required

The `npm-publish` environment must be created manually in the repository settings:

1. Go to **Settings → Environments → New environment**
2. Name it `npm-publish`
3. Configure deployment protection rules (e.g., required reviewers) as needed

## Related Issue

Closes #139

## Checklist

- [x] `environment: npm-publish` added to the `publish` job
- [x] Placement is after `runs-on` and before `permissions`
- [x] No functional changes to build or publish steps
- [x] All CI checks pass