### PR TITLE
ci: add cargo-shear for unused dependency detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,12 @@ jobs:
           tool: cargo-audit
       - name: Run cargo audit
         run: cargo audit
+      - name: Install cargo-shear
+        uses: taiki-e/install-action@c12d62a803cbdfe2e7263af15f5a9548065cb4f2 # v2
+        with:
+          tool: cargo-shear
+      - name: Detect unused dependencies
+        run: cargo shear
 
   rust-lint:
     name: Rust Lint


### PR DESCRIPTION
## Summary

- Add `cargo-shear` to the CI `audit` job to detect unused Rust dependencies
- Uses the same pinned `taiki-e/install-action` SHA as the existing `cargo-audit` step

Closes #144

## Checklist

- [x] CI workflow updated with `cargo-shear` install and run steps
- [x] Action pinned to full commit SHA with version comment
- [x] Verified locally: `cargo shear` passes with no unused dependencies found
- [x] Build passes