### PR TITLE
ci: add scripts/ to CI workflow path triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ on:
       - 'index.d.mts'
       - 'node.js'
       - 'node.d.ts'
+      - 'scripts/**'
       - 'playwright.config.ts'
   pull_request:
     branches: [develop]
@@ -46,6 +47,7 @@ on:
       - 'index.d.mts'
       - 'node.js'
       - 'node.d.ts'
+      - 'scripts/**'
       - 'playwright.config.ts'
 
 concurrency:


### PR DESCRIPTION
## Summary

- Add `scripts/**` to both `push.paths` and `pull_request.paths` in CI workflow
- Ensures changes to build scripts (`optimize-wasm.js`, `sync-cargo-version.js`) trigger CI validation

Closes #157

## Checklist

- [x] `scripts/**` added to `push.paths`
- [x] `scripts/**` added to `pull_request.paths`
- [x] No functional changes to CI behavior