### PR TITLE
perf(lz4): implement incremental streaming for LZ4 compression

### DIFF
--- a/crates/core/src/lz4_stream.rs
+++ b/crates/core/src/lz4_stream.rs
@@ -11,8 +11,8 @@ use crate::ZflateError;
 /// Streaming LZ4 frame compression context.
 ///
 /// Uses `FrameEncoder` internally to produce incremental compressed output
-/// on each `transform()` call. The frame header is emitted on construction,
-/// and block data is flushed as internal buffers fill.
+/// on each `transform()` call. A cursor tracks already-returned bytes, and
+/// old bytes are drained periodically to bound memory usage.
 #[napi]
 pub struct Lz4CompressContext {
     encoder: Option<FrameEncoder<Vec<u8>>>,
@@ -46,8 +46,9 @@ impl Lz4CompressContext {
             })
         })?;
 
-        let output = encoder.get_ref();
+        let output = encoder.get_mut();
         let new_bytes = output[self.cursor..].to_vec();
+        output.drain(..self.cursor);
         self.cursor = output.len();
         Ok(new_bytes.into())
     }
@@ -67,8 +68,9 @@ impl Lz4CompressContext {
             })
         })?;
 
-        let output = encoder.get_ref();
+        let output = encoder.get_mut();
         let new_bytes = output[self.cursor..].to_vec();
+        output.drain(..self.cursor);
         self.cursor = output.len();
         Ok(new_bytes.into())
     }
@@ -89,8 +91,7 @@ impl Lz4CompressContext {
             })
         })?;
 
-        let new_bytes = output[self.cursor..].to_vec();
-        Ok(new_bytes.into())
+        Ok(output[self.cursor..].to_vec().into())
     }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -130,21 +130,19 @@ export declare class GzipDecompressContext {
 /**
  * Streaming LZ4 frame compression context.
  *
- * Buffers input data and produces the compressed LZ4 frame on `finish()`.
- * LZ4 frame format requires finalization to write a valid frame footer.
+ * Uses `FrameEncoder` internally to produce incremental compressed output
+ * on each `transform()` call. A cursor tracks already-returned bytes, and
+ * old bytes are drained periodically to bound memory usage.
  */
 export declare class Lz4CompressContext {
   constructor()
-  /**
-   * Buffer a chunk of data for compression.
-   * Returns an empty buffer (compressed output is produced in `finish()`).
-   */
+  /** Compress a chunk of data. Returns any compressed output produced so far. */
   transform(chunk: Buffer | Uint8Array): Buffer
-  /** Flush the encoder's internal buffer. Returns empty (all output in `finish()`). */
+  /** Flush the encoder's internal buffer. Returns any buffered compressed data. */
   flush(): Buffer
   /**
-   * Finalize the compression stream. Compresses all buffered data and
-   * returns the complete LZ4 frame.
+   * Finalize the compression stream. Writes the LZ4 frame footer.
+   * Must be called once after all data has been transformed.
    */
   finish(): Buffer
 }
@@ -153,6 +151,8 @@ export declare class Lz4CompressContext {
  * Streaming LZ4 frame decompression context.
  *
  * Buffers compressed input and decompresses on `flush()`.
+ * LZ4 frame decompression requires the full compressed input, so true
+ * incremental streaming is not possible with the current lz4_flex API.
  */
 export declare class Lz4DecompressContext {
   constructor(maxOutputSize?: number | undefined | null)


### PR DESCRIPTION
## Summary
- Replace full-input buffering with cursor-based incremental output in `Lz4CompressContext`
- `FrameEncoder` now persists across `transform()` calls, emitting compressed blocks as internal buffers fill
- Decompression remains buffered (lz4_flex `FrameDecoder` requires full input — library limitation)

## Related issue
Closes #182

## Checklist
- [x] Incremental compression output via cursor tracking
- [x] `flush()` forces encoder to write buffered data
- [x] `finish()` emits only remaining frame footer bytes
- [x] Decompression unchanged (documented limitation)
- [x] All 417 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * LZ4圧縮のストリーミング挙動を改善し、入力チャンクごとに増分で圧縮データを出力するようになりました。メモリ使用量が削減され、中間出力の取得が可能です。

* **ドキュメント**
  * 圧縮の増分出力、フラッシュ、終了処理に関する説明を明確化しました。
  * 現行ライブラリでは真の増分復号ができない旨を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->