### PR TITLE
Rename ZflateError to ComprsError and update bench vars

### DIFF
--- a/__test__/brotli.compare.bench.ts
+++ b/__test__/brotli.compare.bench.ts
@@ -19,22 +19,22 @@ const RANDOM_MEDIUM = randomBytes(10_000);
 const RANDOM_LARGE = randomBytes(1_000_000);
 
 // --- Pre-compressed data for decompression benchmarks ---
-const SMALL_ZFLATE = brotliCompress(SMALL);
+const SMALL_COMPRS = brotliCompress(SMALL);
 const SMALL_NODE = nodeBrotliCompress(SMALL);
 
-const MEDIUM_ZFLATE = brotliCompress(MEDIUM);
+const MEDIUM_COMPRS = brotliCompress(MEDIUM);
 const MEDIUM_NODE = nodeBrotliCompress(MEDIUM);
 
-const LARGE_ZFLATE = brotliCompress(LARGE);
+const LARGE_COMPRS = brotliCompress(LARGE);
 const LARGE_NODE = nodeBrotliCompress(LARGE);
 
-const RANDOM_SMALL_ZFLATE = brotliCompress(RANDOM_SMALL);
+const RANDOM_SMALL_COMPRS = brotliCompress(RANDOM_SMALL);
 const RANDOM_SMALL_NODE = nodeBrotliCompress(RANDOM_SMALL);
 
-const RANDOM_MEDIUM_ZFLATE = brotliCompress(RANDOM_MEDIUM);
+const RANDOM_MEDIUM_COMPRS = brotliCompress(RANDOM_MEDIUM);
 const RANDOM_MEDIUM_NODE = nodeBrotliCompress(RANDOM_MEDIUM);
 
-const RANDOM_LARGE_ZFLATE = brotliCompress(RANDOM_LARGE);
+const RANDOM_LARGE_COMPRS = brotliCompress(RANDOM_LARGE);
 const RANDOM_LARGE_NODE = nodeBrotliCompress(RANDOM_LARGE);
 
 // =====================================================
@@ -101,7 +101,7 @@ describe('brotli compress - 1MB random', () => {
 
 describe('brotli decompress - 150B patterned', () => {
   bench('comprs', () => {
-    brotliDecompress(SMALL_ZFLATE);
+    brotliDecompress(SMALL_COMPRS);
   });
   bench('node:zlib', () => {
     nodeBrotliDecompress(SMALL_NODE);
@@ -110,7 +110,7 @@ describe('brotli decompress - 150B patterned', () => {
 
 describe('brotli decompress - 10KB patterned', () => {
   bench('comprs', () => {
-    brotliDecompress(MEDIUM_ZFLATE);
+    brotliDecompress(MEDIUM_COMPRS);
   });
   bench('node:zlib', () => {
     nodeBrotliDecompress(MEDIUM_NODE);
@@ -119,7 +119,7 @@ describe('brotli decompress - 10KB patterned', () => {
 
 describe('brotli decompress - 1MB patterned', () => {
   bench('comprs', () => {
-    brotliDecompress(LARGE_ZFLATE);
+    brotliDecompress(LARGE_COMPRS);
   });
   bench('node:zlib', () => {
     nodeBrotliDecompress(LARGE_NODE);
@@ -128,7 +128,7 @@ describe('brotli decompress - 1MB patterned', () => {
 
 describe('brotli decompress - 150B random', () => {
   bench('comprs', () => {
-    brotliDecompress(RANDOM_SMALL_ZFLATE);
+    brotliDecompress(RANDOM_SMALL_COMPRS);
   });
   bench('node:zlib', () => {
     nodeBrotliDecompress(RANDOM_SMALL_NODE);
@@ -137,7 +137,7 @@ describe('brotli decompress - 150B random', () => {
 
 describe('brotli decompress - 10KB random', () => {
   bench('comprs', () => {
-    brotliDecompress(RANDOM_MEDIUM_ZFLATE);
+    brotliDecompress(RANDOM_MEDIUM_COMPRS);
   });
   bench('node:zlib', () => {
     nodeBrotliDecompress(RANDOM_MEDIUM_NODE);
@@ -146,7 +146,7 @@ describe('brotli decompress - 10KB random', () => {
 
 describe('brotli decompress - 1MB random', () => {
   bench('comprs', () => {
-    brotliDecompress(RANDOM_LARGE_ZFLATE);
+    brotliDecompress(RANDOM_LARGE_COMPRS);
   });
   bench('node:zlib', () => {
     nodeBrotliDecompress(RANDOM_LARGE_NODE);

--- a/__test__/deflate.compare.bench.ts
+++ b/__test__/deflate.compare.bench.ts
@@ -18,32 +18,32 @@ const RANDOM_MEDIUM = randomBytes(10_000);
 const RANDOM_LARGE = randomBytes(1_000_000);
 
 // --- Pre-compressed data for decompression benchmarks ---
-const SMALL_ZFLATE = deflateCompress(SMALL);
+const SMALL_COMPRS = deflateCompress(SMALL);
 const SMALL_PAKO = Buffer.from(pako.deflateRaw(SMALL));
 const SMALL_FFLATE = Buffer.from(deflateSync(SMALL));
 const SMALL_NODE = nodeDeflate(SMALL);
 
-const MEDIUM_ZFLATE = deflateCompress(MEDIUM);
+const MEDIUM_COMPRS = deflateCompress(MEDIUM);
 const MEDIUM_PAKO = Buffer.from(pako.deflateRaw(MEDIUM));
 const MEDIUM_FFLATE = Buffer.from(deflateSync(MEDIUM));
 const MEDIUM_NODE = nodeDeflate(MEDIUM);
 
-const LARGE_ZFLATE = deflateCompress(LARGE);
+const LARGE_COMPRS = deflateCompress(LARGE);
 const LARGE_PAKO = Buffer.from(pako.deflateRaw(LARGE));
 const LARGE_FFLATE = Buffer.from(deflateSync(LARGE));
 const LARGE_NODE = nodeDeflate(LARGE);
 
-const RANDOM_SMALL_ZFLATE = deflateCompress(RANDOM_SMALL);
+const RANDOM_SMALL_COMPRS = deflateCompress(RANDOM_SMALL);
 const RANDOM_SMALL_PAKO = Buffer.from(pako.deflateRaw(RANDOM_SMALL));
 const RANDOM_SMALL_FFLATE = Buffer.from(deflateSync(RANDOM_SMALL));
 const RANDOM_SMALL_NODE = nodeDeflate(RANDOM_SMALL);
 
-const RANDOM_MEDIUM_ZFLATE = deflateCompress(RANDOM_MEDIUM);
+const RANDOM_MEDIUM_COMPRS = deflateCompress(RANDOM_MEDIUM);
 const RANDOM_MEDIUM_PAKO = Buffer.from(pako.deflateRaw(RANDOM_MEDIUM));
 const RANDOM_MEDIUM_FFLATE = Buffer.from(deflateSync(RANDOM_MEDIUM));
 const RANDOM_MEDIUM_NODE = nodeDeflate(RANDOM_MEDIUM);
 
-const RANDOM_LARGE_ZFLATE = deflateCompress(RANDOM_LARGE);
+const RANDOM_LARGE_COMPRS = deflateCompress(RANDOM_LARGE);
 const RANDOM_LARGE_PAKO = Buffer.from(pako.deflateRaw(RANDOM_LARGE));
 const RANDOM_LARGE_FFLATE = Buffer.from(deflateSync(RANDOM_LARGE));
 const RANDOM_LARGE_NODE = nodeDeflate(RANDOM_LARGE);
@@ -148,7 +148,7 @@ describe('deflate compress - 1MB random', () => {
 
 describe('deflate decompress - 150B patterned', () => {
   bench('comprs', () => {
-    deflateDecompress(SMALL_ZFLATE);
+    deflateDecompress(SMALL_COMPRS);
   });
   bench('pako', () => {
     pako.inflateRaw(SMALL_PAKO);
@@ -163,7 +163,7 @@ describe('deflate decompress - 150B patterned', () => {
 
 describe('deflate decompress - 10KB patterned', () => {
   bench('comprs', () => {
-    deflateDecompress(MEDIUM_ZFLATE);
+    deflateDecompress(MEDIUM_COMPRS);
   });
   bench('pako', () => {
     pako.inflateRaw(MEDIUM_PAKO);
@@ -178,7 +178,7 @@ describe('deflate decompress - 10KB patterned', () => {
 
 describe('deflate decompress - 1MB patterned', () => {
   bench('comprs', () => {
-    deflateDecompress(LARGE_ZFLATE);
+    deflateDecompress(LARGE_COMPRS);
   });
   bench('pako', () => {
     pako.inflateRaw(LARGE_PAKO);
@@ -193,7 +193,7 @@ describe('deflate decompress - 1MB patterned', () => {
 
 describe('deflate decompress - 150B random', () => {
   bench('comprs', () => {
-    deflateDecompress(RANDOM_SMALL_ZFLATE);
+    deflateDecompress(RANDOM_SMALL_COMPRS);
   });
   bench('pako', () => {
     pako.inflateRaw(RANDOM_SMALL_PAKO);
@@ -208,7 +208,7 @@ describe('deflate decompress - 150B random', () => {
 
 describe('deflate decompress - 10KB random', () => {
   bench('comprs', () => {
-    deflateDecompress(RANDOM_MEDIUM_ZFLATE);
+    deflateDecompress(RANDOM_MEDIUM_COMPRS);
   });
   bench('pako', () => {
     pako.inflateRaw(RANDOM_MEDIUM_PAKO);
@@ -223,7 +223,7 @@ describe('deflate decompress - 10KB random', () => {
 
 describe('deflate decompress - 1MB random', () => {
   bench('comprs', () => {
-    deflateDecompress(RANDOM_LARGE_ZFLATE);
+    deflateDecompress(RANDOM_LARGE_COMPRS);
   });
   bench('pako', () => {
     pako.inflateRaw(RANDOM_LARGE_PAKO);

--- a/__test__/gzip.compare.bench.ts
+++ b/__test__/gzip.compare.bench.ts
@@ -18,32 +18,32 @@ const RANDOM_MEDIUM = randomBytes(10_000);
 const RANDOM_LARGE = randomBytes(1_000_000);
 
 // --- Pre-compressed data for decompression benchmarks ---
-const SMALL_ZFLATE = gzipCompress(SMALL);
+const SMALL_COMPRS = gzipCompress(SMALL);
 const SMALL_PAKO = Buffer.from(pako.gzip(SMALL));
 const SMALL_FFLATE = Buffer.from(gzipSync(SMALL));
 const SMALL_NODE = nodeGzip(SMALL);
 
-const MEDIUM_ZFLATE = gzipCompress(MEDIUM);
+const MEDIUM_COMPRS = gzipCompress(MEDIUM);
 const MEDIUM_PAKO = Buffer.from(pako.gzip(MEDIUM));
 const MEDIUM_FFLATE = Buffer.from(gzipSync(MEDIUM));
 const MEDIUM_NODE = nodeGzip(MEDIUM);
 
-const LARGE_ZFLATE = gzipCompress(LARGE);
+const LARGE_COMPRS = gzipCompress(LARGE);
 const LARGE_PAKO = Buffer.from(pako.gzip(LARGE));
 const LARGE_FFLATE = Buffer.from(gzipSync(LARGE));
 const LARGE_NODE = nodeGzip(LARGE);
 
-const RANDOM_SMALL_ZFLATE = gzipCompress(RANDOM_SMALL);
+const RANDOM_SMALL_COMPRS = gzipCompress(RANDOM_SMALL);
 const RANDOM_SMALL_PAKO = Buffer.from(pako.gzip(RANDOM_SMALL));
 const RANDOM_SMALL_FFLATE = Buffer.from(gzipSync(RANDOM_SMALL));
 const RANDOM_SMALL_NODE = nodeGzip(RANDOM_SMALL);
 
-const RANDOM_MEDIUM_ZFLATE = gzipCompress(RANDOM_MEDIUM);
+const RANDOM_MEDIUM_COMPRS = gzipCompress(RANDOM_MEDIUM);
 const RANDOM_MEDIUM_PAKO = Buffer.from(pako.gzip(RANDOM_MEDIUM));
 const RANDOM_MEDIUM_FFLATE = Buffer.from(gzipSync(RANDOM_MEDIUM));
 const RANDOM_MEDIUM_NODE = nodeGzip(RANDOM_MEDIUM);
 
-const RANDOM_LARGE_ZFLATE = gzipCompress(RANDOM_LARGE);
+const RANDOM_LARGE_COMPRS = gzipCompress(RANDOM_LARGE);
 const RANDOM_LARGE_PAKO = Buffer.from(pako.gzip(RANDOM_LARGE));
 const RANDOM_LARGE_FFLATE = Buffer.from(gzipSync(RANDOM_LARGE));
 const RANDOM_LARGE_NODE = nodeGzip(RANDOM_LARGE);
@@ -148,7 +148,7 @@ describe('gzip compress - 1MB random', () => {
 
 describe('gzip decompress - 150B patterned', () => {
   bench('comprs', () => {
-    gzipDecompress(SMALL_ZFLATE);
+    gzipDecompress(SMALL_COMPRS);
   });
   bench('pako', () => {
     pako.ungzip(SMALL_PAKO);
@@ -163,7 +163,7 @@ describe('gzip decompress - 150B patterned', () => {
 
 describe('gzip decompress - 10KB patterned', () => {
   bench('comprs', () => {
-    gzipDecompress(MEDIUM_ZFLATE);
+    gzipDecompress(MEDIUM_COMPRS);
   });
   bench('pako', () => {
     pako.ungzip(MEDIUM_PAKO);
@@ -178,7 +178,7 @@ describe('gzip decompress - 10KB patterned', () => {
 
 describe('gzip decompress - 1MB patterned', () => {
   bench('comprs', () => {
-    gzipDecompress(LARGE_ZFLATE);
+    gzipDecompress(LARGE_COMPRS);
   });
   bench('pako', () => {
     pako.ungzip(LARGE_PAKO);
@@ -193,7 +193,7 @@ describe('gzip decompress - 1MB patterned', () => {
 
 describe('gzip decompress - 150B random', () => {
   bench('comprs', () => {
-    gzipDecompress(RANDOM_SMALL_ZFLATE);
+    gzipDecompress(RANDOM_SMALL_COMPRS);
   });
   bench('pako', () => {
     pako.ungzip(RANDOM_SMALL_PAKO);
@@ -208,7 +208,7 @@ describe('gzip decompress - 150B random', () => {
 
 describe('gzip decompress - 10KB random', () => {
   bench('comprs', () => {
-    gzipDecompress(RANDOM_MEDIUM_ZFLATE);
+    gzipDecompress(RANDOM_MEDIUM_COMPRS);
   });
   bench('pako', () => {
     pako.ungzip(RANDOM_MEDIUM_PAKO);
@@ -223,7 +223,7 @@ describe('gzip decompress - 10KB random', () => {
 
 describe('gzip decompress - 1MB random', () => {
   bench('comprs', () => {
-    gzipDecompress(RANDOM_LARGE_ZFLATE);
+    gzipDecompress(RANDOM_LARGE_COMPRS);
   });
   bench('pako', () => {
     pako.ungzip(RANDOM_LARGE_PAKO);

--- a/crates/core/src/brotli_impl.rs
+++ b/crates/core/src/brotli_impl.rs
@@ -6,7 +6,7 @@ use napi::Task;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
-use crate::ZflateError;
+use crate::ComprsError;
 
 /// Default compression quality for brotli.
 const DEFAULT_QUALITY: u32 = 6;
@@ -29,7 +29,7 @@ pub fn brotli_compress(data: Either<Buffer, Uint8Array>, quality: Option<u32>) -
     let quality = quality.unwrap_or(DEFAULT_QUALITY);
     if quality > 11 {
         return Err(
-            ZflateError::InvalidArg("brotli quality must be between 0 and 11".to_string()).into(),
+            ComprsError::InvalidArg("brotli quality must be between 0 and 11".to_string()).into(),
         );
     }
     let input = crate::as_bytes(&data);
@@ -39,7 +39,7 @@ pub fn brotli_compress(data: Either<Buffer, Uint8Array>, quality: Option<u32>) -
         let mut compressor =
             brotli::CompressorWriter::new(&mut output, BUFFER_SIZE, quality, LG_WINDOW_SIZE);
         compressor.write_all(input).map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "brotli compress",
                 source: e.into(),
             })
@@ -106,7 +106,7 @@ impl Task for BrotliCompressTask {
                 LG_WINDOW_SIZE,
             );
             compressor.write_all(&self.data).map_err(|e| {
-                napi::Error::from(ZflateError::Operation {
+                napi::Error::from(ComprsError::Operation {
                     context: "brotli compress",
                     source: e.into(),
                 })
@@ -133,7 +133,7 @@ pub fn brotli_compress_async(
     let quality = quality.unwrap_or(DEFAULT_QUALITY);
     if quality > 11 {
         return Err(
-            ZflateError::InvalidArg("brotli quality must be between 0 and 11".to_string()).into(),
+            ComprsError::InvalidArg("brotli quality must be between 0 and 11".to_string()).into(),
         );
     }
     let input = crate::as_bytes(&data).to_vec();

--- a/crates/core/src/brotli_stream.rs
+++ b/crates/core/src/brotli_stream.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
-use crate::ZflateError;
+use crate::ComprsError;
 
 /// Default compression quality for brotli.
 const DEFAULT_QUALITY: u32 = 6;
@@ -31,7 +31,7 @@ impl BrotliCompressContext {
     pub fn new(quality: Option<u32>) -> Result<Self> {
         let quality = quality.unwrap_or(DEFAULT_QUALITY);
         if quality > 11 {
-            return Err(ZflateError::InvalidArg(
+            return Err(ComprsError::InvalidArg(
                 "brotli quality must be between 0 and 11".to_string(),
             )
             .into());
@@ -50,10 +50,10 @@ impl BrotliCompressContext {
         let compressor = self
             .compressor
             .as_mut()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("brotli stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("brotli stream")))?;
 
         compressor.write_all(crate::as_bytes(&chunk)).map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "brotli stream compress",
                 source: e.into(),
             })
@@ -70,10 +70,10 @@ impl BrotliCompressContext {
         let compressor = self
             .compressor
             .as_mut()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("brotli stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("brotli stream")))?;
 
         compressor.flush().map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "brotli stream flush",
                 source: e.into(),
             })
@@ -90,7 +90,7 @@ impl BrotliCompressContext {
         let compressor = self
             .compressor
             .take()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("brotli stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("brotli stream")))?;
 
         // into_inner drops the CompressorWriter, which flushes remaining data
         // and writes the brotli stream end marker
@@ -130,7 +130,7 @@ impl BrotliDecompressContext {
         self.decompressor
             .write_all(crate::as_bytes(&chunk))
             .map_err(|e| {
-                napi::Error::from(ZflateError::Operation {
+                napi::Error::from(ComprsError::Operation {
                     context: "brotli stream decompress",
                     source: e.into(),
                 })
@@ -140,7 +140,7 @@ impl BrotliDecompressContext {
         let data = std::mem::take(self.decompressor.get_mut());
         self.total_output += data.len();
         if self.total_output > self.max_output_size {
-            return Err(ZflateError::SizeLimit {
+            return Err(ComprsError::SizeLimit {
                 context: "brotli stream decompress",
                 limit: self.max_output_size,
             }
@@ -153,7 +153,7 @@ impl BrotliDecompressContext {
     #[napi]
     pub fn flush(&mut self) -> Result<Buffer> {
         self.decompressor.flush().map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "brotli stream flush",
                 source: e.into(),
             })
@@ -162,7 +162,7 @@ impl BrotliDecompressContext {
         let data = std::mem::take(self.decompressor.get_mut());
         self.total_output += data.len();
         if self.total_output > self.max_output_size {
-            return Err(ZflateError::SizeLimit {
+            return Err(ComprsError::SizeLimit {
                 context: "brotli stream decompress",
                 limit: self.max_output_size,
             }

--- a/crates/core/src/detect.rs
+++ b/crates/core/src/detect.rs
@@ -8,7 +8,7 @@ use napi::Task;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
-use crate::ZflateError;
+use crate::ComprsError;
 
 /// Zstd magic number: 0xFD2FB528 (little-endian).
 const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
@@ -71,7 +71,7 @@ pub fn decompress(data: Either<Buffer, Uint8Array>) -> Result<Buffer> {
         Format::Gzip => crate::gzip_decompress(data),
         Format::Brotli => crate::brotli_decompress(data),
         Format::Lz4 => crate::lz4_decompress(data),
-        Format::Unknown => Err(ZflateError::InvalidArg(
+        Format::Unknown => Err(ComprsError::InvalidArg(
             "unable to detect compression format; use algorithm-specific functions (zstdDecompress, gzipDecompress, brotliDecompress, lz4Decompress) instead".to_string(),
         )
         .into()),
@@ -154,7 +154,7 @@ impl Task for DecompressTask {
                 };
                 let capacity = capacity.max(1024);
                 zstd::bulk::decompress(&self.data, capacity).map_err(|e| {
-                    ZflateError::Operation {
+                    ComprsError::Operation {
                         context: "zstd decompress",
                         source: e.into(),
                     }
@@ -169,7 +169,7 @@ impl Task for DecompressTask {
                 let mut buf = [0u8; BUFFER_SIZE];
                 loop {
                     let n = decoder.read(&mut buf).map_err(|e| {
-                        napi::Error::from(ZflateError::Operation {
+                        napi::Error::from(ComprsError::Operation {
                             context: "gzip decompress",
                             source: e.into(),
                         })
@@ -178,7 +178,7 @@ impl Task for DecompressTask {
                         break;
                     }
                     if output.len() + n > MAX_DECOMPRESSED_SIZE {
-                        return Err(ZflateError::SizeLimit {
+                        return Err(ComprsError::SizeLimit {
                             context: "gzip decompress",
                             limit: MAX_DECOMPRESSED_SIZE,
                         }
@@ -196,7 +196,7 @@ impl Task for DecompressTask {
                 let mut buf = [0u8; BUFFER_SIZE];
                 loop {
                     let n = decompressor.read(&mut buf).map_err(|e| {
-                        napi::Error::from(ZflateError::Operation {
+                        napi::Error::from(ComprsError::Operation {
                             context: "brotli decompress",
                             source: e.into(),
                         })
@@ -205,7 +205,7 @@ impl Task for DecompressTask {
                         break;
                     }
                     if output.len() + n > MAX_DECOMPRESSED_SIZE {
-                        return Err(ZflateError::SizeLimit {
+                        return Err(ComprsError::SizeLimit {
                             context: "brotli decompress",
                             limit: MAX_DECOMPRESSED_SIZE,
                         }
@@ -226,7 +226,7 @@ impl Task for DecompressTask {
                     "lz4 decompress",
                 )
             }
-            Format::Unknown => Err(ZflateError::InvalidArg(
+            Format::Unknown => Err(ComprsError::InvalidArg(
                 "unable to detect compression format; use algorithm-specific functions (zstdDecompress, gzipDecompress, brotliDecompress, lz4Decompress) instead".to_string(),
             )
             .into()),

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 /// Errors produced by comprs compression and decompression operations.
 #[derive(Error, Debug)]
-pub enum ZflateError {
+pub enum ComprsError {
     /// Compression or decompression operation failure.
     #[error("{context} failed: {source}")]
     Operation {
@@ -35,10 +35,10 @@ pub enum ZflateError {
     StreamFinished(&'static str),
 }
 
-impl From<ZflateError> for napi::Error {
-    fn from(e: ZflateError) -> Self {
+impl From<ComprsError> for napi::Error {
+    fn from(e: ComprsError) -> Self {
         match &e {
-            ZflateError::InvalidArg(_) => Error::new(Status::InvalidArg, e.to_string()),
+            ComprsError::InvalidArg(_) => Error::new(Status::InvalidArg, e.to_string()),
             _ => Error::new(Status::GenericFailure, e.to_string()),
         }
     }

--- a/crates/core/src/gzip.rs
+++ b/crates/core/src/gzip.rs
@@ -10,7 +10,7 @@ use napi::Task;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
-use crate::ZflateError;
+use crate::ComprsError;
 
 /// Default compression level for gzip/deflate (flate2 default = 6).
 const DEFAULT_LEVEL: u32 = 6;
@@ -26,7 +26,7 @@ const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
 pub fn gzip_compress(data: Either<Buffer, Uint8Array>, level: Option<u32>) -> Result<Buffer> {
     let level = level.unwrap_or(DEFAULT_LEVEL);
     if level > 9 {
-        return Err(ZflateError::InvalidArg(
+        return Err(ComprsError::InvalidArg(
             "gzip compression level must be between 0 and 9".to_string(),
         )
         .into());
@@ -35,13 +35,13 @@ pub fn gzip_compress(data: Either<Buffer, Uint8Array>, level: Option<u32>) -> Re
 
     let mut encoder = GzEncoder::new(Vec::with_capacity(input.len()), Compression::new(level));
     encoder.write_all(input).map_err(|e| {
-        napi::Error::from(ZflateError::Operation {
+        napi::Error::from(ComprsError::Operation {
             context: "gzip compress",
             source: e.into(),
         })
     })?;
     encoder.finish().map(|v| v.into()).map_err(|e| {
-        napi::Error::from(ZflateError::Operation {
+        napi::Error::from(ComprsError::Operation {
             context: "gzip compress",
             source: e.into(),
         })
@@ -85,7 +85,7 @@ pub fn gzip_compress_with_header(
 ) -> Result<Buffer> {
     let level = level.unwrap_or(DEFAULT_LEVEL);
     if level > 9 {
-        return Err(ZflateError::InvalidArg(
+        return Err(ComprsError::InvalidArg(
             "gzip compression level must be between 0 and 9".to_string(),
         )
         .into());
@@ -102,13 +102,13 @@ pub fn gzip_compress_with_header(
 
     let mut encoder = builder.write(Vec::with_capacity(input.len()), Compression::new(level));
     encoder.write_all(input).map_err(|e| {
-        napi::Error::from(ZflateError::Operation {
+        napi::Error::from(ComprsError::Operation {
             context: "gzip compress with header",
             source: e.into(),
         })
     })?;
     encoder.finish().map(|v| v.into()).map_err(|e| {
-        napi::Error::from(ZflateError::Operation {
+        napi::Error::from(ComprsError::Operation {
             context: "gzip compress with header",
             source: e.into(),
         })
@@ -123,7 +123,7 @@ pub fn gzip_read_header(data: Either<Buffer, Uint8Array>) -> Result<GzipHeader> 
     let input = crate::as_bytes(&data);
     let decoder = GzDecoder::new(input);
     let header = decoder.header().ok_or_else(|| {
-        napi::Error::from(ZflateError::InvalidArg(
+        napi::Error::from(ComprsError::InvalidArg(
             "invalid gzip data: unable to parse header".to_string(),
         ))
     })?;
@@ -178,7 +178,7 @@ fn decompress_gzip_with_limit(input: &[u8], max_size: usize) -> Result<Buffer> {
 pub fn deflate_compress(data: Either<Buffer, Uint8Array>, level: Option<u32>) -> Result<Buffer> {
     let level = level.unwrap_or(DEFAULT_LEVEL);
     if level > 9 {
-        return Err(ZflateError::InvalidArg(
+        return Err(ComprsError::InvalidArg(
             "deflate compression level must be between 0 and 9".to_string(),
         )
         .into());
@@ -187,13 +187,13 @@ pub fn deflate_compress(data: Either<Buffer, Uint8Array>, level: Option<u32>) ->
 
     let mut encoder = DeflateEncoder::new(Vec::with_capacity(input.len()), Compression::new(level));
     encoder.write_all(input).map_err(|e| {
-        napi::Error::from(ZflateError::Operation {
+        napi::Error::from(ComprsError::Operation {
             context: "deflate compress",
             source: e.into(),
         })
     })?;
     encoder.finish().map(|v| v.into()).map_err(|e| {
-        napi::Error::from(ZflateError::Operation {
+        napi::Error::from(ComprsError::Operation {
             context: "deflate compress",
             source: e.into(),
         })
@@ -248,13 +248,13 @@ impl Task for GzipCompressTask {
             Compression::new(self.level),
         );
         encoder.write_all(&self.data).map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "gzip compress",
                 source: e.into(),
             })
         })?;
         encoder.finish().map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "gzip compress",
                 source: e.into(),
             })
@@ -277,7 +277,7 @@ pub fn gzip_compress_async(
 ) -> Result<AsyncTask<GzipCompressTask>> {
     let level = level.unwrap_or(DEFAULT_LEVEL);
     if level > 9 {
-        return Err(ZflateError::InvalidArg(
+        return Err(ComprsError::InvalidArg(
             "gzip compression level must be between 0 and 9".to_string(),
         )
         .into());
@@ -333,13 +333,13 @@ impl Task for DeflateCompressTask {
             Compression::new(self.level),
         );
         encoder.write_all(&self.data).map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "deflate compress",
                 source: e.into(),
             })
         })?;
         encoder.finish().map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "deflate compress",
                 source: e.into(),
             })
@@ -362,7 +362,7 @@ pub fn deflate_compress_async(
 ) -> Result<AsyncTask<DeflateCompressTask>> {
     let level = level.unwrap_or(DEFAULT_LEVEL);
     if level > 9 {
-        return Err(ZflateError::InvalidArg(
+        return Err(ComprsError::InvalidArg(
             "deflate compression level must be between 0 and 9".to_string(),
         )
         .into());

--- a/crates/core/src/gzip_stream.rs
+++ b/crates/core/src/gzip_stream.rs
@@ -7,7 +7,7 @@ use flate2::write::{DeflateDecoder, DeflateEncoder, GzEncoder, MultiGzDecoder};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
-use crate::ZflateError;
+use crate::ComprsError;
 
 /// Default compression level for gzip/deflate (same as zlib default).
 const DEFAULT_LEVEL: u32 = 6;
@@ -27,7 +27,7 @@ impl GzipCompressContext {
     pub fn new(level: Option<u32>) -> Result<Self> {
         let level = level.unwrap_or(DEFAULT_LEVEL);
         if level > 9 {
-            return Err(ZflateError::InvalidArg(
+            return Err(ComprsError::InvalidArg(
                 "gzip compression level must be between 0 and 9".to_string(),
             )
             .into());
@@ -45,10 +45,10 @@ impl GzipCompressContext {
         let encoder = self
             .encoder
             .as_mut()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("gzip stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("gzip stream")))?;
 
         encoder.write_all(crate::as_bytes(&chunk)).map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "gzip stream compress",
                 source: e.into(),
             })
@@ -65,10 +65,10 @@ impl GzipCompressContext {
         let encoder = self
             .encoder
             .as_mut()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("gzip stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("gzip stream")))?;
 
         encoder.flush().map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "gzip stream flush",
                 source: e.into(),
             })
@@ -86,10 +86,10 @@ impl GzipCompressContext {
         let encoder = self
             .encoder
             .take()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("gzip stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("gzip stream")))?;
 
         encoder.finish().map(|v| v.into()).map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "gzip stream finish",
                 source: e.into(),
             })
@@ -128,13 +128,13 @@ impl GzipDecompressContext {
         let decoder = self
             .decoder
             .as_mut()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("gzip stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("gzip stream")))?;
 
         let input = crate::as_bytes(&chunk);
         let mut pos = 0;
         while pos < input.len() {
             let n = decoder.write(&input[pos..]).map_err(|e| {
-                napi::Error::from(ZflateError::Operation {
+                napi::Error::from(ComprsError::Operation {
                     context: "gzip stream decompress",
                     source: e.into(),
                 })
@@ -149,7 +149,7 @@ impl GzipDecompressContext {
         let data = std::mem::take(output);
         self.total_output += data.len();
         if self.total_output > self.max_output_size {
-            return Err(ZflateError::SizeLimit {
+            return Err(ComprsError::SizeLimit {
                 context: "gzip stream decompress",
                 limit: self.max_output_size,
             }
@@ -164,10 +164,10 @@ impl GzipDecompressContext {
         let decoder = self
             .decoder
             .as_mut()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("gzip stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("gzip stream")))?;
 
         decoder.flush().map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "gzip stream flush",
                 source: e.into(),
             })
@@ -177,7 +177,7 @@ impl GzipDecompressContext {
         let data = std::mem::take(output);
         self.total_output += data.len();
         if self.total_output > self.max_output_size {
-            return Err(ZflateError::SizeLimit {
+            return Err(ComprsError::SizeLimit {
                 context: "gzip stream decompress",
                 limit: self.max_output_size,
             }
@@ -193,10 +193,10 @@ impl GzipDecompressContext {
         let decoder = self
             .decoder
             .take()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("gzip stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("gzip stream")))?;
 
         decoder.finish().map(|v| v.into()).map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "gzip stream finish",
                 source: e.into(),
             })
@@ -219,7 +219,7 @@ impl DeflateCompressContext {
     pub fn new(level: Option<u32>) -> Result<Self> {
         let level = level.unwrap_or(DEFAULT_LEVEL);
         if level > 9 {
-            return Err(ZflateError::InvalidArg(
+            return Err(ComprsError::InvalidArg(
                 "deflate compression level must be between 0 and 9".to_string(),
             )
             .into());
@@ -237,10 +237,10 @@ impl DeflateCompressContext {
         let encoder = self
             .encoder
             .as_mut()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("deflate stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("deflate stream")))?;
 
         encoder.write_all(crate::as_bytes(&chunk)).map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "deflate stream compress",
                 source: e.into(),
             })
@@ -257,10 +257,10 @@ impl DeflateCompressContext {
         let encoder = self
             .encoder
             .as_mut()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("deflate stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("deflate stream")))?;
 
         encoder.flush().map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "deflate stream flush",
                 source: e.into(),
             })
@@ -278,10 +278,10 @@ impl DeflateCompressContext {
         let encoder = self
             .encoder
             .take()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("deflate stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("deflate stream")))?;
 
         encoder.finish().map(|v| v.into()).map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "deflate stream finish",
                 source: e.into(),
             })
@@ -320,10 +320,10 @@ impl DeflateDecompressContext {
         let decoder = self
             .decoder
             .as_mut()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("deflate stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("deflate stream")))?;
 
         decoder.write_all(crate::as_bytes(&chunk)).map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "deflate stream decompress",
                 source: e.into(),
             })
@@ -333,7 +333,7 @@ impl DeflateDecompressContext {
         let data = std::mem::take(output);
         self.total_output += data.len();
         if self.total_output > self.max_output_size {
-            return Err(ZflateError::SizeLimit {
+            return Err(ComprsError::SizeLimit {
                 context: "deflate stream decompress",
                 limit: self.max_output_size,
             }
@@ -348,10 +348,10 @@ impl DeflateDecompressContext {
         let decoder = self
             .decoder
             .as_mut()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("deflate stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("deflate stream")))?;
 
         decoder.flush().map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "deflate stream flush",
                 source: e.into(),
             })
@@ -361,7 +361,7 @@ impl DeflateDecompressContext {
         let data = std::mem::take(output);
         self.total_output += data.len();
         if self.total_output > self.max_output_size {
-            return Err(ZflateError::SizeLimit {
+            return Err(ComprsError::SizeLimit {
                 context: "deflate stream decompress",
                 limit: self.max_output_size,
             }
@@ -377,10 +377,10 @@ impl DeflateDecompressContext {
         let decoder = self
             .decoder
             .take()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("deflate stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("deflate stream")))?;
 
         decoder.finish().map(|v| v.into()).map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "deflate stream finish",
                 source: e.into(),
             })

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -17,7 +17,7 @@ use std::io::Read;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
-pub use error::ZflateError;
+pub use error::ComprsError;
 
 /// Maximum allowed decompressed size (256 MB) to prevent memory exhaustion.
 const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
@@ -36,7 +36,7 @@ fn validate_max_output_size(max_output_size: Option<f64>) -> Result<usize> {
         None => Ok(MAX_DECOMPRESSED_SIZE),
         Some(size) => {
             if !size.is_finite() || size < 0.0 {
-                Err(ZflateError::InvalidArg(
+                Err(ComprsError::InvalidArg(
                     "maxOutputSize must be a positive finite number".to_string(),
                 )
                 .into())
@@ -59,7 +59,7 @@ fn validate_capacity(capacity: f64) -> Result<usize> {
         || capacity > usize::MAX as f64
     {
         return Err(
-            ZflateError::InvalidArg("capacity must be a non-negative integer".to_string()).into(),
+            ComprsError::InvalidArg("capacity must be a non-negative integer".to_string()).into(),
         );
     }
     Ok(capacity as usize)
@@ -81,13 +81,13 @@ fn decompress_with_limit(
         .take((max_size as u64).saturating_add(1))
         .read_to_end(&mut output)
         .map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context,
                 source: e.into(),
             })
         })?;
     if output.len() > max_size {
-        return Err(ZflateError::SizeLimit {
+        return Err(ComprsError::SizeLimit {
             context,
             limit: max_size,
         }

--- a/crates/core/src/lz4.rs
+++ b/crates/core/src/lz4.rs
@@ -7,7 +7,7 @@ use napi::Task;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
-use crate::ZflateError;
+use crate::ComprsError;
 
 /// Maximum allowed decompressed size (256 MB) to prevent memory exhaustion.
 const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
@@ -22,13 +22,13 @@ pub fn lz4_compress(data: Either<Buffer, Uint8Array>) -> Result<Buffer> {
     let mut output = Vec::with_capacity(input.len());
     let mut encoder = FrameEncoder::new(&mut output);
     encoder.write_all(input).map_err(|e| {
-        napi::Error::from(ZflateError::Operation {
+        napi::Error::from(ComprsError::Operation {
             context: "lz4 compress",
             source: e.into(),
         })
     })?;
     encoder.finish().map_err(|e| {
-        napi::Error::from(ZflateError::Operation {
+        napi::Error::from(ComprsError::Operation {
             context: "lz4 compress",
             source: e.into(),
         })
@@ -82,13 +82,13 @@ impl Task for Lz4CompressTask {
         let mut output = Vec::with_capacity(self.data.len());
         let mut encoder = FrameEncoder::new(&mut output);
         encoder.write_all(&self.data).map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "lz4 compress",
                 source: e.into(),
             })
         })?;
         encoder.finish().map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "lz4 compress",
                 source: e.into(),
             })

--- a/crates/core/src/lz4_stream.rs
+++ b/crates/core/src/lz4_stream.rs
@@ -6,7 +6,7 @@ use lz4_flex::frame::{FrameDecoder, FrameEncoder};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
-use crate::ZflateError;
+use crate::ComprsError;
 
 /// Streaming LZ4 frame compression context.
 ///
@@ -36,11 +36,11 @@ impl Lz4CompressContext {
         let encoder = self
             .encoder
             .as_mut()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("lz4 stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("lz4 stream")))?;
 
         let input = crate::as_bytes(&chunk);
         encoder.write_all(input).map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "lz4 stream compress",
                 source: e.into(),
             })
@@ -59,10 +59,10 @@ impl Lz4CompressContext {
         let encoder = self
             .encoder
             .as_mut()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("lz4 stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("lz4 stream")))?;
 
         encoder.flush().map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "lz4 stream flush",
                 source: e.into(),
             })
@@ -82,10 +82,10 @@ impl Lz4CompressContext {
         let encoder = self
             .encoder
             .take()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("lz4 stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("lz4 stream")))?;
 
         let output = encoder.finish().map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "lz4 stream finish",
                 source: e.into(),
             })

--- a/crates/core/src/zstd.rs
+++ b/crates/core/src/zstd.rs
@@ -4,7 +4,7 @@ use napi::Task;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
-use crate::ZflateError;
+use crate::ComprsError;
 
 /// Default compression level for zstd (same as the C library default).
 const DEFAULT_LEVEL: i32 = 3;
@@ -22,7 +22,7 @@ const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
 pub fn zstd_compress(data: Either<Buffer, Uint8Array>, level: Option<i32>) -> Result<Buffer> {
     let level = level.unwrap_or(DEFAULT_LEVEL);
     if !(-131072..=22).contains(&level) {
-        return Err(ZflateError::InvalidArg(
+        return Err(ComprsError::InvalidArg(
             "zstd compression level must be between -131072 and 22".to_string(),
         )
         .into());
@@ -32,7 +32,7 @@ pub fn zstd_compress(data: Either<Buffer, Uint8Array>, level: Option<i32>) -> Re
     zstd::bulk::compress(input, level)
         .map(|v| v.into())
         .map_err(|e| {
-            ZflateError::Operation {
+            ComprsError::Operation {
                 context: "zstd compress",
                 source: e.into(),
             }
@@ -52,7 +52,7 @@ impl Task for ZstdCompressTask {
 
     fn compute(&mut self) -> Result<Self::Output> {
         zstd::bulk::compress(&self.data, self.level).map_err(|e| {
-            ZflateError::Operation {
+            ComprsError::Operation {
                 context: "zstd compress",
                 source: e.into(),
             }
@@ -78,7 +78,7 @@ pub fn zstd_compress_async(
 ) -> Result<AsyncTask<ZstdCompressTask>> {
     let level = level.unwrap_or(DEFAULT_LEVEL);
     if !(-131072..=22).contains(&level) {
-        return Err(ZflateError::InvalidArg(
+        return Err(ComprsError::InvalidArg(
             "zstd compression level must be between -131072 and 22".to_string(),
         )
         .into());
@@ -104,7 +104,7 @@ impl Task for ZstdDecompressTask {
         let capacity = capacity.max(1024);
 
         zstd::bulk::decompress(&self.data, capacity).map_err(|e| {
-            ZflateError::Operation {
+            ComprsError::Operation {
                 context: "zstd decompress",
                 source: e.into(),
             }
@@ -149,7 +149,7 @@ pub fn zstd_decompress(data: Either<Buffer, Uint8Array>) -> Result<Buffer> {
     zstd::bulk::decompress(input, capacity)
         .map(|v| v.into())
         .map_err(|e| {
-            ZflateError::Operation {
+            ComprsError::Operation {
                 context: "zstd decompress",
                 source: e.into(),
             }
@@ -172,7 +172,7 @@ pub fn zstd_decompress_with_capacity(
     zstd::bulk::decompress(input, cap)
         .map(|v| v.into())
         .map_err(|e| {
-            ZflateError::Operation {
+            ComprsError::Operation {
                 context: "zstd decompress",
                 source: e.into(),
             }
@@ -206,7 +206,7 @@ pub fn zstd_train_dictionary(
     zstd::dict::from_samples(&sample_vecs, max_size)
         .map(|v| v.into())
         .map_err(|e| {
-            ZflateError::Operation {
+            ComprsError::Operation {
                 context: "zstd dictionary training",
                 source: e.into(),
             }
@@ -226,7 +226,7 @@ pub fn zstd_compress_with_dict(
 ) -> Result<Buffer> {
     let level = level.unwrap_or(DEFAULT_LEVEL);
     if !(-131072..=22).contains(&level) {
-        return Err(ZflateError::InvalidArg(
+        return Err(ComprsError::InvalidArg(
             "zstd compression level must be between -131072 and 22".to_string(),
         )
         .into());
@@ -236,14 +236,14 @@ pub fn zstd_compress_with_dict(
 
     let mut compressor =
         zstd::bulk::Compressor::with_dictionary(level, dict_bytes).map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "zstd compressor init",
                 source: e.into(),
             })
         })?;
 
     compressor.compress(input).map(|v| v.into()).map_err(|e| {
-        napi::Error::from(ZflateError::Operation {
+        napi::Error::from(ComprsError::Operation {
             context: "zstd compress with dict",
             source: e.into(),
         })
@@ -268,7 +268,7 @@ pub fn zstd_decompress_with_dict(
     let capacity = capacity.max(1024);
 
     let mut decompressor = zstd::bulk::Decompressor::with_dictionary(dict_bytes).map_err(|e| {
-        napi::Error::from(ZflateError::Operation {
+        napi::Error::from(ComprsError::Operation {
             context: "zstd decompressor init",
             source: e.into(),
         })
@@ -278,7 +278,7 @@ pub fn zstd_decompress_with_dict(
         .decompress(input, capacity)
         .map(|v| v.into())
         .map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "zstd decompress with dict",
                 source: e.into(),
             })
@@ -297,7 +297,7 @@ impl Task for ZstdDecompressWithCapacityTask {
 
     fn compute(&mut self) -> Result<Self::Output> {
         zstd::bulk::decompress(&self.data, self.capacity).map_err(|e| {
-            ZflateError::Operation {
+            ComprsError::Operation {
                 context: "zstd decompress",
                 source: e.into(),
             }
@@ -341,13 +341,13 @@ impl Task for ZstdCompressWithDictTask {
     fn compute(&mut self) -> Result<Self::Output> {
         let mut compressor = zstd::bulk::Compressor::with_dictionary(self.level, &self.dict)
             .map_err(|e| {
-                napi::Error::from(ZflateError::Operation {
+                napi::Error::from(ComprsError::Operation {
                     context: "zstd compressor init",
                     source: e.into(),
                 })
             })?;
         compressor.compress(&self.data).map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "zstd compress with dict",
                 source: e.into(),
             })
@@ -371,7 +371,7 @@ pub fn zstd_compress_with_dict_async(
 ) -> Result<AsyncTask<ZstdCompressWithDictTask>> {
     let level = level.unwrap_or(DEFAULT_LEVEL);
     if !(-131072..=22).contains(&level) {
-        return Err(ZflateError::InvalidArg(
+        return Err(ComprsError::InvalidArg(
             "zstd compression level must be between -131072 and 22".to_string(),
         )
         .into());
@@ -404,13 +404,13 @@ impl Task for ZstdDecompressWithDictTask {
 
         let mut decompressor =
             zstd::bulk::Decompressor::with_dictionary(&self.dict).map_err(|e| {
-                napi::Error::from(ZflateError::Operation {
+                napi::Error::from(ComprsError::Operation {
                     context: "zstd decompressor init",
                     source: e.into(),
                 })
             })?;
         decompressor.decompress(&self.data, capacity).map_err(|e| {
-            napi::Error::from(ZflateError::Operation {
+            napi::Error::from(ComprsError::Operation {
                 context: "zstd decompress with dict",
                 source: e.into(),
             })
@@ -450,7 +450,7 @@ impl Task for ZstdTrainDictionaryTask {
 
     fn compute(&mut self) -> Result<Self::Output> {
         zstd::dict::from_samples(&self.samples, self.max_dict_size).map_err(|e| {
-            ZflateError::Operation {
+            ComprsError::Operation {
                 context: "zstd dictionary training",
                 source: e.into(),
             }

--- a/crates/core/src/zstd_stream.rs
+++ b/crates/core/src/zstd_stream.rs
@@ -4,7 +4,7 @@ use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use zstd::stream::raw::{Decoder, Encoder, InBuffer, Operation, OutBuffer};
 
-use crate::ZflateError;
+use crate::ComprsError;
 
 /// Default compression level for zstd (same as the C library default).
 const DEFAULT_LEVEL: i32 = 3;
@@ -27,13 +27,13 @@ impl ZstdCompressContext {
     pub fn new(level: Option<i32>) -> Result<Self> {
         let level = level.unwrap_or(DEFAULT_LEVEL);
         if !(-131072..=22).contains(&level) {
-            return Err(ZflateError::InvalidArg(
+            return Err(ComprsError::InvalidArg(
                 "zstd compression level must be between -131072 and 22".to_string(),
             )
             .into());
         }
         let encoder = Encoder::new(level).map_err(|e| {
-            napi::Error::from(ZflateError::Creation {
+            napi::Error::from(ComprsError::Creation {
                 context: "zstd encoder",
                 source: e.into(),
             })
@@ -50,7 +50,7 @@ impl ZstdCompressContext {
         let encoder = self
             .encoder
             .as_mut()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("zstd stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("zstd stream")))?;
 
         let input = crate::as_bytes(&chunk);
         let bound = zstd::zstd_safe::compress_bound(input.len());
@@ -62,7 +62,7 @@ impl ZstdCompressContext {
         while in_buf.pos() < in_buf.src.len() {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
             encoder.run(&mut in_buf, &mut out_buf).map_err(|e| {
-                napi::Error::from(ZflateError::Operation {
+                napi::Error::from(ComprsError::Operation {
                     context: "zstd stream compress",
                     source: e.into(),
                 })
@@ -83,7 +83,7 @@ impl ZstdCompressContext {
         let encoder = self
             .encoder
             .as_mut()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("zstd stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("zstd stream")))?;
 
         let mut output = vec![0u8; INITIAL_BUF_SIZE];
         let mut total_written = 0;
@@ -91,7 +91,7 @@ impl ZstdCompressContext {
         loop {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
             let remaining = encoder.flush(&mut out_buf).map_err(|e| {
-                napi::Error::from(ZflateError::Operation {
+                napi::Error::from(ComprsError::Operation {
                     context: "zstd stream flush",
                     source: e.into(),
                 })
@@ -116,7 +116,7 @@ impl ZstdCompressContext {
         let mut encoder = self
             .encoder
             .take()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("zstd stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("zstd stream")))?;
 
         let mut output = vec![0u8; INITIAL_BUF_SIZE];
         let mut total_written = 0;
@@ -124,7 +124,7 @@ impl ZstdCompressContext {
         loop {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
             let remaining = encoder.finish(&mut out_buf, true).map_err(|e| {
-                napi::Error::from(ZflateError::Operation {
+                napi::Error::from(ComprsError::Operation {
                     context: "zstd stream finish",
                     source: e.into(),
                 })
@@ -160,7 +160,7 @@ impl ZstdDecompressContext {
     pub fn new(max_output_size: Option<f64>) -> Result<Self> {
         let max_size = crate::validate_max_output_size(max_output_size)?;
         let decoder = Decoder::new().map_err(|e| {
-            napi::Error::from(ZflateError::Creation {
+            napi::Error::from(ComprsError::Creation {
                 context: "zstd decoder",
                 source: e.into(),
             })
@@ -186,14 +186,14 @@ impl ZstdDecompressContext {
         while in_buf.pos() < in_buf.src.len() {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
             self.decoder.run(&mut in_buf, &mut out_buf).map_err(|e| {
-                napi::Error::from(ZflateError::Operation {
+                napi::Error::from(ComprsError::Operation {
                     context: "zstd stream decompress",
                     source: e.into(),
                 })
             })?;
             total_written = out_buf.pos();
             if self.total_output + total_written > self.max_output_size {
-                return Err(ZflateError::SizeLimit {
+                return Err(ComprsError::SizeLimit {
                     context: "zstd stream decompress",
                     limit: self.max_output_size,
                 }
@@ -218,7 +218,7 @@ impl ZstdDecompressContext {
         loop {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
             let remaining = self.decoder.flush(&mut out_buf).map_err(|e| {
-                napi::Error::from(ZflateError::Operation {
+                napi::Error::from(ComprsError::Operation {
                     context: "zstd stream flush",
                     source: e.into(),
                 })
@@ -252,14 +252,14 @@ impl ZstdCompressDictContext {
     pub fn new(dict: Either<Buffer, Uint8Array>, level: Option<i32>) -> Result<Self> {
         let level = level.unwrap_or(DEFAULT_LEVEL);
         if !(-131072..=22).contains(&level) {
-            return Err(ZflateError::InvalidArg(
+            return Err(ComprsError::InvalidArg(
                 "zstd compression level must be between -131072 and 22".to_string(),
             )
             .into());
         }
         let dict_bytes = crate::as_bytes(&dict);
         let encoder = Encoder::with_dictionary(level, dict_bytes).map_err(|e| {
-            napi::Error::from(ZflateError::Creation {
+            napi::Error::from(ComprsError::Creation {
                 context: "zstd dict encoder",
                 source: e.into(),
             })
@@ -276,7 +276,7 @@ impl ZstdCompressDictContext {
         let encoder = self
             .encoder
             .as_mut()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("zstd stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("zstd stream")))?;
 
         let input = crate::as_bytes(&chunk);
         let bound = zstd::zstd_safe::compress_bound(input.len());
@@ -288,7 +288,7 @@ impl ZstdCompressDictContext {
         while in_buf.pos() < in_buf.src.len() {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
             encoder.run(&mut in_buf, &mut out_buf).map_err(|e| {
-                napi::Error::from(ZflateError::Operation {
+                napi::Error::from(ComprsError::Operation {
                     context: "zstd stream compress",
                     source: e.into(),
                 })
@@ -309,7 +309,7 @@ impl ZstdCompressDictContext {
         let encoder = self
             .encoder
             .as_mut()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("zstd stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("zstd stream")))?;
 
         let mut output = vec![0u8; INITIAL_BUF_SIZE];
         let mut total_written = 0;
@@ -317,7 +317,7 @@ impl ZstdCompressDictContext {
         loop {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
             let remaining = encoder.flush(&mut out_buf).map_err(|e| {
-                napi::Error::from(ZflateError::Operation {
+                napi::Error::from(ComprsError::Operation {
                     context: "zstd stream flush",
                     source: e.into(),
                 })
@@ -342,7 +342,7 @@ impl ZstdCompressDictContext {
         let mut encoder = self
             .encoder
             .take()
-            .ok_or_else(|| napi::Error::from(ZflateError::StreamFinished("zstd stream")))?;
+            .ok_or_else(|| napi::Error::from(ComprsError::StreamFinished("zstd stream")))?;
 
         let mut output = vec![0u8; INITIAL_BUF_SIZE];
         let mut total_written = 0;
@@ -350,7 +350,7 @@ impl ZstdCompressDictContext {
         loop {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
             let remaining = encoder.finish(&mut out_buf, true).map_err(|e| {
-                napi::Error::from(ZflateError::Operation {
+                napi::Error::from(ComprsError::Operation {
                     context: "zstd stream finish",
                     source: e.into(),
                 })
@@ -387,7 +387,7 @@ impl ZstdDecompressDictContext {
         let max_size = crate::validate_max_output_size(max_output_size)?;
         let dict_bytes = crate::as_bytes(&dict);
         let decoder = Decoder::with_dictionary(dict_bytes).map_err(|e| {
-            napi::Error::from(ZflateError::Creation {
+            napi::Error::from(ComprsError::Creation {
                 context: "zstd dict decoder",
                 source: e.into(),
             })
@@ -413,14 +413,14 @@ impl ZstdDecompressDictContext {
         while in_buf.pos() < in_buf.src.len() {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
             self.decoder.run(&mut in_buf, &mut out_buf).map_err(|e| {
-                napi::Error::from(ZflateError::Operation {
+                napi::Error::from(ComprsError::Operation {
                     context: "zstd stream decompress",
                     source: e.into(),
                 })
             })?;
             total_written = out_buf.pos();
             if self.total_output + total_written > self.max_output_size {
-                return Err(ZflateError::SizeLimit {
+                return Err(ComprsError::SizeLimit {
                     context: "zstd stream decompress",
                     limit: self.max_output_size,
                 }
@@ -445,7 +445,7 @@ impl ZstdDecompressDictContext {
         loop {
             let mut out_buf = OutBuffer::around_pos(&mut output, total_written);
             let remaining = self.decoder.flush(&mut out_buf).map_err(|e| {
-                napi::Error::from(ZflateError::Operation {
+                napi::Error::from(ComprsError::Operation {
                     context: "zstd stream flush",
                     source: e.into(),
                 })


### PR DESCRIPTION
## Summary
- Rename Rust error type `ZflateError` → `ComprsError` across all 11 source files in `crates/core/src/`
- Rename benchmark variable names `*_ZFLATE` → `*_COMPRS` in 3 compare benchmark files
- Follow-up to #190 (package rename from zflate to comprs)

## Related issue
Closes #191

## Checklist
- [x] `cargo test` — 58 tests pass
- [x] `cargo clippy` — no errors
- [x] `pnpm run check` — no errors
- [x] No functional changes, internal symbol rename only