### PR TITLE
fix: add missing LZ4 exports to ESM entry point and complete API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ const decompressed = zstdDecompressWithDict(compressed, dict);
 | Function | Description |
 | --- | --- |
 | `gzipCompress(data, level?)` | Compress with gzip. Level: 0-9 (default: 6) |
+| `gzipCompressWithHeader(data, header, level?)` | Compress with custom gzip header (filename, mtime) |
+| `gzipReadHeader(data)` | Read gzip header metadata without decompressing |
 | `gzipDecompress(data)` | Decompress gzip data |
 | `gzipDecompressWithCapacity(data, capacity)` | Decompress with explicit output size limit |
 | `deflateCompress(data, level?)` | Compress with raw deflate. Level: 0-9 (default: 6) |
@@ -178,6 +180,13 @@ const decompressed = zstdDecompressWithDict(compressed, dict);
 | --- | --- |
 | `decompress(data)` | Auto-detect format and decompress (zstd, gzip, brotli, lz4) |
 | `detectFormat(data)` | Detect compression format. Returns `'zstd'`, `'gzip'`, `'brotli'`, `'lz4'`, or `'unknown'` |
+
+#### Utilities
+
+| Function | Description |
+| --- | --- |
+| `crc32(data, initialValue?)` | Compute CRC32 checksum (supports incremental computation) |
+| `version()` | Returns the library version |
 
 #### zstd Dictionary
 
@@ -220,6 +229,7 @@ All one-shot functions have async variants that run on the libuv thread pool, ke
 | `createLz4DecompressStream()` | Create an LZ4 decompression `TransformStream` |
 | `createZstdCompressDictStream(dict, level?)` | Streaming zstd compression with dictionary |
 | `createZstdDecompressDictStream(dict)` | Streaming zstd decompression with dictionary |
+| `createDecompressStream()` | Auto-detect format and create a decompression `TransformStream` |
 
 ### Node.js Transform Streams
 
@@ -251,6 +261,7 @@ await pipeline(
 | `createLz4DecompressTransform()` | Node.js Transform for LZ4 decompression |
 | `createZstdCompressDictTransform(dict, level?)` | Node.js Transform for zstd dict compression |
 | `createZstdDecompressDictTransform(dict)` | Node.js Transform for zstd dict decompression |
+| `createDecompressTransform()` | Auto-detect format and create a decompression Transform |
 
 ## Supported Algorithms
 

--- a/browser-entry.js
+++ b/browser-entry.js
@@ -26,6 +26,8 @@ export {
   gzipCompressAsync,
   gzipDecompress,
   gzipDecompressAsync,
+  gzipCompressWithHeader,
+  gzipReadHeader,
   gzipDecompressWithCapacity,
   gzipDecompressWithCapacityAsync,
   lz4Compress,

--- a/index.mjs
+++ b/index.mjs
@@ -53,6 +53,14 @@ export const {
   GzipDecompressContext,
   DeflateCompressContext,
   DeflateDecompressContext,
+  lz4Compress,
+  lz4Decompress,
+  lz4DecompressWithCapacity,
+  lz4CompressAsync,
+  lz4DecompressAsync,
+  lz4DecompressWithCapacityAsync,
+  Lz4CompressContext,
+  Lz4DecompressContext,
 } = binding;
 
 export const {
@@ -66,5 +74,7 @@ export const {
   createGzipDecompressStream,
   createDeflateCompressStream,
   createDeflateDecompressStream,
+  createLz4CompressStream,
+  createLz4DecompressStream,
   createDecompressStream,
 } = streams;


### PR DESCRIPTION
## Summary

Second pre-release audit found critical gaps:

- **`index.mjs` (CRITICAL)**: LZ4 one-shot APIs (`lz4Compress`, `lz4Decompress`, etc.), Context classes (`Lz4CompressContext`, `Lz4DecompressContext`), and streaming functions (`createLz4CompressStream`, `createLz4DecompressStream`) were completely missing from the ESM entry point — ESM `import` users could not access LZ4 at all
- **`browser-entry.js`**: `gzipCompressWithHeader` and `gzipReadHeader` were not re-exported for browser builds
- **`README.md`**: Added documentation for `gzipCompressWithHeader`, `gzipReadHeader`, `crc32()`, `version()`, `createDecompressStream()`, and `createDecompressTransform()`

## Checklist

- [x] Add LZ4 APIs + contexts to index.mjs binding exports
- [x] Add LZ4 streaming to index.mjs streams exports
- [x] Add gzip header functions to browser-entry.js
- [x] Document all missing functions in README.md
- [x] `pnpm run check` passed
- [x] `pnpm run typecheck` passed
- [x] `pnpm test` passed (419 tests)
- [x] `pnpm run build` passed

Closes #195