### PR TITLE
fix(docs): add missing lz4 to decompressAsync doc and clarify async section

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ const decompressed = zstdDecompressWithDict(compressed, dict);
 
 ### Async
 
-All one-shot functions have async variants that run on the libuv thread pool, keeping the event loop free:
+All compression and decompression functions have async variants (suffix `Async`) that run on the libuv thread pool, keeping the event loop free:
 
 | Function | Description |
 | --- | --- |

--- a/crates/core/src/detect.rs
+++ b/crates/core/src/detect.rs
@@ -244,7 +244,7 @@ impl Task for DecompressTask {
 /// appropriate algorithm. Returns a Promise that resolves to the
 /// decompressed data as a Buffer.
 ///
-/// Supported formats: zstd, gzip, brotli.
+/// Supported formats: zstd, gzip, brotli, lz4.
 /// Raw deflate is not supported (no magic bytes to distinguish it).
 #[napi]
 pub fn decompress_async(data: Either<Buffer, Uint8Array>) -> AsyncTask<DecompressTask> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -328,7 +328,7 @@ export declare function decompress(data: Buffer | Uint8Array): Buffer
  * appropriate algorithm. Returns a Promise that resolves to the
  * decompressed data as a Buffer.
  *
- * Supported formats: zstd, gzip, brotli.
+ * Supported formats: zstd, gzip, brotli, lz4.
  * Raw deflate is not supported (no magic bytes to distinguish it).
  */
 export declare function decompressAsync(data: Buffer | Uint8Array): Promise<Buffer>


### PR DESCRIPTION
## Summary
- Fix `decompressAsync` doc comment in `detect.rs` to include `lz4` in supported formats list (implementation already supports it)
- Regenerate `index.d.ts` to propagate the corrected JSDoc
- Clarify README async section: "All one-shot functions" → "All compression and decompression functions" (utility functions like `crc32`, `version`, `gzipReadHeader` don't have async variants)

Closes #197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント

* 非同期圧縮・解凍関数の提供範囲を明確化しました。すべての圧縮・解凍機能に対して「Async」サフィックス付きの非同期バリアントが利用可能であることを説明しました。
* 非同期解凍APIがサポートする圧縮形式のリストに**lz4**を追加しました。zstd、gzip、brotliに加えてlz4の自動検出に対応していることを記載しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->