### PR TITLE
perf(ci): remove JS walltime benchmarks from CodSpeed

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -6,35 +6,15 @@ on:
     paths:
       - "Cargo.toml"
       - "Cargo.lock"
-      - "package.json"
       - "crates/**"
-      - "__test__/**/*.bench.ts"
-      - "__test__/bench-fixtures.ts"
-      - "vitest.config.mts"
       - ".github/workflows/codspeed.yml"
-      - "streams.js"
-      - "streams.d.ts"
-      - "index.mjs"
-      - "index.d.mts"
-      - "node.js"
-      - "node.d.ts"
   pull_request:
     branches: [develop]
     paths:
       - "Cargo.toml"
       - "Cargo.lock"
-      - "package.json"
       - "crates/**"
-      - "__test__/**/*.bench.ts"
-      - "__test__/bench-fixtures.ts"
-      - "vitest.config.mts"
       - ".github/workflows/codspeed.yml"
-      - "streams.js"
-      - "streams.d.ts"
-      - "index.mjs"
-      - "index.d.mts"
-      - "node.js"
-      - "node.d.ts"
   workflow_dispatch:
 
 concurrency:
@@ -69,30 +49,3 @@ jobs:
         with:
           mode: simulation
           run: cargo codspeed run -p comprs-bench
-
-  js-benchmarks:
-    name: JS Benchmarks
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-          cache: pnpm
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: codspeed
-      - run: pnpm install --frozen-lockfile
-
-      - name: Build native module
-        run: pnpm run build
-
-      - name: Run benchmarks
-        uses: CodSpeedHQ/action@v4
-        with:
-          mode: walltime
-          run: pnpm run bench:ci


### PR DESCRIPTION
## Summary

- Remove JS walltime benchmark job from CodSpeed workflow — the primary source of false regression reports
- Keep Rust simulation benchmarks (instruction counting, <1% variance) as the sole CodSpeed regression detection mechanism
- Narrow workflow path triggers to Rust-only files (`crates/**`, `Cargo.toml`, `Cargo.lock`)

## Problem

CodSpeed Performance Analysis has been failing on nearly every PR since #174, including documentation-only changes:

| PR | Change | CodSpeed Report |
|----|--------|----------------|
| #198 | Docs fix only | FAILURE (-52.79%) |
| #196 | ESM export add | FAILURE (-36.81%) |
| #194 | LZ4 docs | FAILURE |
| #192 | Error type rename | FAILURE |

Root causes:
1. JS walltime on standard `ubuntu-latest` — CodSpeed warns this produces "inconsistent data"
2. CPU heterogeneity (AMD EPYC vs Intel Xeon assigned randomly) — glibc's CPU-adaptive malloc causes 20-50% swings
3. BASE and HEAD compared across different runtime environments

## Why this approach

- Rust simulation mode uses Callgrind instruction counting — deterministic, <1% variance, hardware-agnostic
- All 5 compression algorithms (gzip, deflate, zstd, brotli, lz4) are covered by Rust benchmarks with both compression and decompression at 10KB and 1MB sizes
- JS benchmarks remain available locally via `pnpm run bench`

## Manual follow-up needed

After merging, archive stale JS walltime benchmark results in the [CodSpeed dashboard](https://codspeed.io/derodero24/comprs) to remove skipped benchmarks from future reports.

Closes #200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * JavaScriptベンチマーク機能をワークフローから削除しました。Rustベンチマークテストは継続されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->