### PR TITLE
chore: add .mcp.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ docs/*
 # Claude Code (local development only)
 CLAUDE.md
 .claude/
+.mcp.json
 test-results/
 playwright-report/
 deno.lock


### PR DESCRIPTION
## Summary

- Add `.mcp.json` (MCP server configuration) to `.gitignore` to prevent project-scoped MCP configs from being committed

Closes #203

## Checklist

- [x] `.gitignore` updated
- [x] All checks passing (biome, typecheck, test, clippy, cargo test, cargo-deny)