### PR TITLE
Update ESM smoke test to cover all exports

### DIFF
--- a/__test__/esm-import.mjs
+++ b/__test__/esm-import.mjs
@@ -5,37 +5,57 @@ import {
   brotliDecompress,
   brotliDecompressAsync,
   brotliDecompressWithCapacity,
+  brotliDecompressWithCapacityAsync,
+  crc32,
   createBrotliCompressStream,
   createBrotliDecompressStream,
+  createDecompressStream,
   createDeflateCompressStream,
   createDeflateDecompressStream,
   createGzipCompressStream,
   createGzipDecompressStream,
+  createLz4CompressStream,
+  createLz4DecompressStream,
   createZstdCompressDictStream,
   createZstdCompressStream,
   createZstdDecompressDictStream,
   createZstdDecompressStream,
   decompress,
+  decompressAsync,
   deflateCompress,
   deflateCompressAsync,
   deflateDecompress,
   deflateDecompressAsync,
   deflateDecompressWithCapacity,
+  deflateDecompressWithCapacityAsync,
   detectFormat,
   gzipCompress,
   gzipCompressAsync,
+  gzipCompressWithHeader,
   gzipDecompress,
   gzipDecompressAsync,
   gzipDecompressWithCapacity,
+  gzipDecompressWithCapacityAsync,
+  gzipReadHeader,
+  lz4Compress,
+  lz4CompressAsync,
+  lz4Decompress,
+  lz4DecompressAsync,
+  lz4DecompressWithCapacity,
+  lz4DecompressWithCapacityAsync,
   version,
   zstdCompress,
   zstdCompressAsync,
   zstdCompressWithDict,
+  zstdCompressWithDictAsync,
   zstdDecompress,
   zstdDecompressAsync,
   zstdDecompressWithCapacity,
+  zstdDecompressWithCapacityAsync,
   zstdDecompressWithDict,
+  zstdDecompressWithDictAsync,
   zstdTrainDictionary,
+  zstdTrainDictionaryAsync,
 } from '../index.mjs';
 
 assert.strictEqual(typeof version, 'function', 'version should be a function');
@@ -93,9 +113,19 @@ assert.strictEqual(
   'brotliDecompressWithCapacity should be a function',
 );
 assert.strictEqual(
+  typeof brotliDecompressWithCapacityAsync,
+  'function',
+  'brotliDecompressWithCapacityAsync should be a function',
+);
+assert.strictEqual(
   typeof zstdDecompressWithCapacity,
   'function',
   'zstdDecompressWithCapacity should be a function',
+);
+assert.strictEqual(
+  typeof zstdDecompressWithCapacityAsync,
+  'function',
+  'zstdDecompressWithCapacityAsync should be a function',
 );
 assert.strictEqual(
   typeof gzipDecompressWithCapacity,
@@ -103,11 +133,22 @@ assert.strictEqual(
   'gzipDecompressWithCapacity should be a function',
 );
 assert.strictEqual(
+  typeof gzipDecompressWithCapacityAsync,
+  'function',
+  'gzipDecompressWithCapacityAsync should be a function',
+);
+assert.strictEqual(
   typeof deflateDecompressWithCapacity,
   'function',
   'deflateDecompressWithCapacity should be a function',
 );
+assert.strictEqual(
+  typeof deflateDecompressWithCapacityAsync,
+  'function',
+  'deflateDecompressWithCapacityAsync should be a function',
+);
 assert.strictEqual(typeof decompress, 'function', 'decompress should be a function');
+assert.strictEqual(typeof decompressAsync, 'function', 'decompressAsync should be a function');
 assert.strictEqual(typeof detectFormat, 'function', 'detectFormat should be a function');
 assert.strictEqual(
   typeof zstdTrainDictionary,
@@ -115,14 +156,29 @@ assert.strictEqual(
   'zstdTrainDictionary should be a function',
 );
 assert.strictEqual(
+  typeof zstdTrainDictionaryAsync,
+  'function',
+  'zstdTrainDictionaryAsync should be a function',
+);
+assert.strictEqual(
   typeof zstdCompressWithDict,
   'function',
   'zstdCompressWithDict should be a function',
 );
 assert.strictEqual(
+  typeof zstdCompressWithDictAsync,
+  'function',
+  'zstdCompressWithDictAsync should be a function',
+);
+assert.strictEqual(
   typeof zstdDecompressWithDict,
   'function',
   'zstdDecompressWithDict should be a function',
+);
+assert.strictEqual(
+  typeof zstdDecompressWithDictAsync,
+  'function',
+  'zstdDecompressWithDictAsync should be a function',
 );
 assert.strictEqual(typeof zstdCompressAsync, 'function', 'zstdCompressAsync should be a function');
 assert.strictEqual(
@@ -166,6 +222,46 @@ assert.strictEqual(
   'function',
   'createBrotliDecompressStream should be a function',
 );
+assert.strictEqual(typeof lz4Compress, 'function', 'lz4Compress should be a function');
+assert.strictEqual(typeof lz4Decompress, 'function', 'lz4Decompress should be a function');
+assert.strictEqual(typeof lz4CompressAsync, 'function', 'lz4CompressAsync should be a function');
+assert.strictEqual(
+  typeof lz4DecompressAsync,
+  'function',
+  'lz4DecompressAsync should be a function',
+);
+assert.strictEqual(
+  typeof lz4DecompressWithCapacity,
+  'function',
+  'lz4DecompressWithCapacity should be a function',
+);
+assert.strictEqual(
+  typeof lz4DecompressWithCapacityAsync,
+  'function',
+  'lz4DecompressWithCapacityAsync should be a function',
+);
+assert.strictEqual(
+  typeof createLz4CompressStream,
+  'function',
+  'createLz4CompressStream should be a function',
+);
+assert.strictEqual(
+  typeof createLz4DecompressStream,
+  'function',
+  'createLz4DecompressStream should be a function',
+);
+assert.strictEqual(
+  typeof createDecompressStream,
+  'function',
+  'createDecompressStream should be a function',
+);
+assert.strictEqual(typeof crc32, 'function', 'crc32 should be a function');
+assert.strictEqual(
+  typeof gzipCompressWithHeader,
+  'function',
+  'gzipCompressWithHeader should be a function',
+);
+assert.strictEqual(typeof gzipReadHeader, 'function', 'gzipReadHeader should be a function');
 
 // Zstd round-trip test
 const input = Buffer.from('ESM smoke test');
@@ -187,6 +283,15 @@ assert.deepStrictEqual(dfDecompressed, input, 'deflate round-trip should produce
 const brCompressed = brotliCompress(input);
 const brDecompressed = brotliDecompress(brCompressed);
 assert.deepStrictEqual(brDecompressed, input, 'brotli round-trip should produce identical output');
+
+// LZ4 round-trip test
+const lz4Compressed = lz4Compress(input);
+const lz4Decompressed = lz4Decompress(lz4Compressed);
+assert.deepStrictEqual(lz4Decompressed, input, 'lz4 round-trip should produce identical output');
+
+// CRC32 test
+const crc = crc32(input);
+assert.strictEqual(typeof crc, 'number', 'crc32 should return a number');
 
 // Auto-detect decompress test
 const autoResult = decompress(zstdCompress(input));


### PR DESCRIPTION
## Summary
- Add missing function imports and type assertions to `__test__/esm-import.mjs` to cover all exports from `index.mjs`
- Add LZ4 round-trip test and CRC32 test following existing patterns
- Add assertions for all async variants, capacity variants, dictionary variants, streaming functions, and utility functions

Closes #211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## テスト
* ESM インポートの検証範囲が拡張されました。各種圧縮・展開関数、非同期バージョン、ストリーム機能、CRC32 チェックサムなど複数のエクスポートが正しく機能することを確認する実行時テストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->