### PR TITLE
fix(core): use decompress_with_limit in async auto-detect

### DIFF
--- a/.changeset/fix-decompress-task-double-copy.md
+++ b/.changeset/fix-decompress-task-double-copy.md
@@ -1,0 +1,5 @@
+---
+"comprs": patch
+---
+
+Use `decompress_with_limit` in async auto-detect decompression for gzip and brotli, replacing manual chunk-read loops that performed a double-copy through an intermediate stack buffer.

--- a/crates/core/src/detect.rs
+++ b/crates/core/src/detect.rs
@@ -2,8 +2,6 @@
 //!
 //! Detects the compression format from magic bytes and decompresses accordingly.
 
-use std::io::Read;
-
 use napi::Task;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -133,9 +131,6 @@ fn is_likely_brotli(data: &[u8]) -> bool {
 /// Maximum allowed decompressed size (256 MB) to prevent memory exhaustion.
 const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
 
-/// Default buffer size for chunked read operations.
-const BUFFER_SIZE: usize = 4096;
-
 pub struct DecompressTask {
     data: Vec<u8>,
 }
@@ -162,58 +157,25 @@ impl Task for DecompressTask {
                 })
             }
             Format::Gzip => {
-                let mut decoder =
-                    flate2::read::MultiGzDecoder::new(self.data.as_slice());
-                let mut output =
-                    Vec::with_capacity((self.data.len().saturating_mul(4)).min(MAX_DECOMPRESSED_SIZE));
-                let mut buf = [0u8; BUFFER_SIZE];
-                loop {
-                    let n = decoder.read(&mut buf).map_err(|e| {
-                        napi::Error::from(ComprsError::Operation {
-                            context: "gzip decompress",
-                            source: e.into(),
-                        })
-                    })?;
-                    if n == 0 {
-                        break;
-                    }
-                    if output.len() + n > MAX_DECOMPRESSED_SIZE {
-                        return Err(ComprsError::SizeLimit {
-                            context: "gzip decompress",
-                            limit: MAX_DECOMPRESSED_SIZE,
-                        }
-                        .into());
-                    }
-                    output.extend_from_slice(&buf[..n]);
-                }
-                Ok(output)
+                let decoder = flate2::read::MultiGzDecoder::new(self.data.as_slice());
+                let init_cap = self.data.len().saturating_mul(4).min(MAX_DECOMPRESSED_SIZE);
+                crate::decompress_with_limit(
+                    decoder,
+                    MAX_DECOMPRESSED_SIZE,
+                    init_cap,
+                    "gzip decompress",
+                )
             }
             Format::Brotli => {
-                let mut decompressor =
-                    brotli::Decompressor::new(self.data.as_slice(), BUFFER_SIZE);
-                let mut output =
-                    Vec::with_capacity((self.data.len().saturating_mul(4)).min(MAX_DECOMPRESSED_SIZE));
-                let mut buf = [0u8; BUFFER_SIZE];
-                loop {
-                    let n = decompressor.read(&mut buf).map_err(|e| {
-                        napi::Error::from(ComprsError::Operation {
-                            context: "brotli decompress",
-                            source: e.into(),
-                        })
-                    })?;
-                    if n == 0 {
-                        break;
-                    }
-                    if output.len() + n > MAX_DECOMPRESSED_SIZE {
-                        return Err(ComprsError::SizeLimit {
-                            context: "brotli decompress",
-                            limit: MAX_DECOMPRESSED_SIZE,
-                        }
-                        .into());
-                    }
-                    output.extend_from_slice(&buf[..n]);
-                }
-                Ok(output)
+                let decompressor =
+                    brotli::Decompressor::new(self.data.as_slice(), 4096);
+                let init_cap = self.data.len().saturating_mul(4).min(MAX_DECOMPRESSED_SIZE);
+                crate::decompress_with_limit(
+                    decompressor,
+                    MAX_DECOMPRESSED_SIZE,
+                    init_cap,
+                    "brotli decompress",
+                )
             }
             Format::Lz4 => {
                 let decoder = lz4_flex::frame::FrameDecoder::new(self.data.as_slice());


### PR DESCRIPTION
## Summary
- Replace manual chunk-read loops with double-copy in `DecompressTask::compute()` for gzip and brotli branches
- Now uses `crate::decompress_with_limit()`, matching the pattern already used by the LZ4 branch and per-algorithm async tasks (`GzipDecompressTask`, `BrotliDecompressTask`)
- Remove unused `BUFFER_SIZE` constant and top-level `use std::io::Read` import from `detect.rs`

## Related issue
Closes #207

## Checklist
- [x] `cargo test` passes (58/58)
- [x] `cargo clippy -- -W clippy::all` passes
- [x] Changeset included