### PR TITLE
fix(zstd): validate maxDictSize parameter

### DIFF
--- a/.changeset/validate-max-dict-size.md
+++ b/.changeset/validate-max-dict-size.md
@@ -1,0 +1,5 @@
+---
+"comprs": patch
+---
+
+Fix missing validation for maxDictSize parameter in zstdTrainDictionary

--- a/crates/core/src/zstd.rs
+++ b/crates/core/src/zstd.rs
@@ -195,7 +195,8 @@ pub fn zstd_train_dictionary(
     max_dict_size: Option<f64>,
 ) -> Result<Buffer> {
     let max_size = max_dict_size
-        .map(|s| s as usize)
+        .map(crate::validate_capacity)
+        .transpose()?
         .unwrap_or(DEFAULT_MAX_DICT_SIZE);
 
     let sample_vecs: Vec<Vec<u8>> = samples
@@ -473,18 +474,19 @@ impl Task for ZstdTrainDictionaryTask {
 pub fn zstd_train_dictionary_async(
     samples: Vec<Either<Buffer, Uint8Array>>,
     max_dict_size: Option<f64>,
-) -> AsyncTask<ZstdTrainDictionaryTask> {
+) -> Result<AsyncTask<ZstdTrainDictionaryTask>> {
     let max_size = max_dict_size
-        .map(|s| s as usize)
+        .map(crate::validate_capacity)
+        .transpose()?
         .unwrap_or(DEFAULT_MAX_DICT_SIZE);
     let sample_vecs: Vec<Vec<u8>> = samples
         .iter()
         .map(|s| crate::as_bytes(s).to_vec())
         .collect();
-    AsyncTask::new(ZstdTrainDictionaryTask {
+    Ok(AsyncTask::new(ZstdTrainDictionaryTask {
         samples: sample_vecs,
         max_dict_size: max_size,
-    })
+    }))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Add `validate_capacity()` call for the `maxDictSize` parameter in both `zstdTrainDictionary` (sync) and `zstdTrainDictionaryAsync` functions
- Previously, `max_dict_size` was cast directly from `f64` to `usize` without validation, allowing NaN (→ 0), Infinity (→ usize::MAX), and negative values (→ wrapped huge value) to pass through silently
- The async function's return type is changed from `AsyncTask<...>` to `Result<AsyncTask<...>>` to propagate validation errors

## Related issue

Closes #206

## Checklist

- [x] `cargo test` passes (58 tests)
- [x] `cargo clippy -- -W clippy::all` passes
- [x] `pnpm test` passes (419 tests)
- [x] `pnpm run check` (Biome lint) passes
- [x] `pnpm run typecheck` passes
- [x] Changeset added