### PR TITLE
fix(zstd): enforce maxOutputSize in browser dict decompression

### DIFF
--- a/.changeset/browser-dict-max-output-size.md
+++ b/.changeset/browser-dict-max-output-size.md
@@ -1,0 +1,5 @@
+---
+"comprs": patch
+---
+
+Enforce maxOutputSize in browser WASM ZstdDecompressDictContext by adding zstdDecompressWithDictWithCapacity

--- a/browser-streaming.js
+++ b/browser-streaming.js
@@ -17,6 +17,7 @@ import {
   zstdDecompressWithCapacity as _zstdDecompressWithCapacity,
   zstdCompressWithDict as _zstdCompressWithDict,
   zstdDecompressWithDict as _zstdDecompressWithDict,
+  zstdDecompressWithDictWithCapacity as _zstdDecompressWithDictWithCapacity,
 } from 'comprs-wasm32-wasi'
 
 /**
@@ -361,6 +362,9 @@ export class ZstdDecompressDictContext {
     this._finished = true
     const data = concatChunks(this._chunks)
     this._chunks = []
+    if (this._maxOutputSize != null) {
+      return _zstdDecompressWithDictWithCapacity(data, this._dict, this._maxOutputSize)
+    }
     return _zstdDecompressWithDict(data, this._dict)
   }
 }

--- a/crates/core/src/zstd.rs
+++ b/crates/core/src/zstd.rs
@@ -286,6 +286,40 @@ pub fn zstd_decompress_with_dict(
         })
 }
 
+/// Decompress Zstandard-compressed data that was compressed with a dictionary,
+/// with explicit capacity.
+///
+/// Use this when the decompressed size exceeds the default 256 MB limit.
+/// The `capacity` parameter specifies the maximum decompressed size in bytes.
+/// The same dictionary used for compression must be provided.
+#[napi]
+pub fn zstd_decompress_with_dict_with_capacity(
+    data: Either<Buffer, Uint8Array>,
+    dict: Either<Buffer, Uint8Array>,
+    capacity: f64,
+) -> Result<Buffer> {
+    let cap = crate::validate_capacity(capacity)?;
+    let input = crate::as_bytes(&data);
+    let dict_bytes = crate::as_bytes(&dict);
+
+    let mut decompressor = zstd::bulk::Decompressor::with_dictionary(dict_bytes).map_err(|e| {
+        napi::Error::from(ComprsError::Operation {
+            context: "zstd decompressor init",
+            source: e.into(),
+        })
+    })?;
+
+    decompressor
+        .decompress(input, cap)
+        .map(|v| v.into())
+        .map_err(|e| {
+            napi::Error::from(ComprsError::Operation {
+                context: "zstd decompress with dict",
+                source: e.into(),
+            })
+        })
+}
+
 pub struct ZstdDecompressWithCapacityTask {
     data: Vec<u8>,
     capacity: usize,

--- a/index.d.ts
+++ b/index.d.ts
@@ -620,6 +620,16 @@ export declare function zstdDecompressWithDict(data: Buffer | Uint8Array, dict: 
 export declare function zstdDecompressWithDictAsync(data: Buffer | Uint8Array, dict: Buffer | Uint8Array): Promise<Buffer>
 
 /**
+ * Decompress Zstandard-compressed data that was compressed with a dictionary,
+ * with explicit capacity.
+ *
+ * Use this when the decompressed size exceeds the default 256 MB limit.
+ * The `capacity` parameter specifies the maximum decompressed size in bytes.
+ * The same dictionary used for compression must be provided.
+ */
+export declare function zstdDecompressWithDictWithCapacity(data: Buffer | Uint8Array, dict: Buffer | Uint8Array, capacity: number): Buffer
+
+/**
  * Train a zstd dictionary from sample data.
  *
  * The dictionary can be used with `zstdCompressWithDict` and `zstdDecompressWithDict`

--- a/index.js
+++ b/index.js
@@ -630,5 +630,6 @@ module.exports.zstdDecompressWithCapacity = nativeBinding.zstdDecompressWithCapa
 module.exports.zstdDecompressWithCapacityAsync = nativeBinding.zstdDecompressWithCapacityAsync
 module.exports.zstdDecompressWithDict = nativeBinding.zstdDecompressWithDict
 module.exports.zstdDecompressWithDictAsync = nativeBinding.zstdDecompressWithDictAsync
+module.exports.zstdDecompressWithDictWithCapacity = nativeBinding.zstdDecompressWithDictWithCapacity
 module.exports.zstdTrainDictionary = nativeBinding.zstdTrainDictionary
 module.exports.zstdTrainDictionaryAsync = nativeBinding.zstdTrainDictionaryAsync


### PR DESCRIPTION
## Summary
- Add `zstdDecompressWithDictWithCapacity` Rust function to support dictionary decompression with explicit capacity
- Fix `ZstdDecompressDictContext.flush()` in `browser-streaming.js` to use the new function when `maxOutputSize` is set
- Previously, `maxOutputSize` was accepted but silently ignored in the browser WASM shim

## Related issue
Closes #208

## Checklist
- [x] `cargo test` passes
- [x] `cargo clippy -- -W clippy::all` passes
- [x] `pnpm run check` passes
- [x] `pnpm test` passes (419 tests)
- [x] Changeset included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ブラウザのZstdデコンプレッション機能で、辞書使用時に最大出力サイズを指定できるようになりました。これにより、メモリ使用量をより厳密に制御でき、リソース管理が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->