### PR TITLE
refactor(core): consolidate MAX_DECOMPRESSED_SIZE constant

### DIFF
--- a/crates/core/src/brotli_impl.rs
+++ b/crates/core/src/brotli_impl.rs
@@ -17,9 +17,6 @@ const BUFFER_SIZE: usize = 4096;
 /// Default log2 of the sliding window size for brotli.
 const LG_WINDOW_SIZE: u32 = 22;
 
-/// Maximum allowed decompressed size (256 MB) to prevent memory exhaustion.
-const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
-
 /// Compress data using Brotli.
 ///
 /// Returns the compressed data as a Buffer.
@@ -58,10 +55,10 @@ pub fn brotli_compress(data: Either<Buffer, Uint8Array>, quality: Option<u32>) -
 pub fn brotli_decompress(data: Either<Buffer, Uint8Array>) -> Result<Buffer> {
     let input = crate::as_bytes(&data);
     let decompressor = brotli::Decompressor::new(input, BUFFER_SIZE);
-    let init_cap = (input.len().saturating_mul(4)).min(MAX_DECOMPRESSED_SIZE);
+    let init_cap = (input.len().saturating_mul(4)).min(crate::MAX_DECOMPRESSED_SIZE);
     crate::decompress_with_limit(
         decompressor,
-        MAX_DECOMPRESSED_SIZE,
+        crate::MAX_DECOMPRESSED_SIZE,
         init_cap,
         "brotli decompress",
     )
@@ -154,10 +151,10 @@ impl Task for BrotliDecompressTask {
 
     fn compute(&mut self) -> Result<Self::Output> {
         let decompressor = brotli::Decompressor::new(self.data.as_slice(), BUFFER_SIZE);
-        let init_cap = (self.data.len().saturating_mul(4)).min(MAX_DECOMPRESSED_SIZE);
+        let init_cap = (self.data.len().saturating_mul(4)).min(crate::MAX_DECOMPRESSED_SIZE);
         crate::decompress_with_limit(
             decompressor,
-            MAX_DECOMPRESSED_SIZE,
+            crate::MAX_DECOMPRESSED_SIZE,
             init_cap,
             "brotli decompress",
         )

--- a/crates/core/src/detect.rs
+++ b/crates/core/src/detect.rs
@@ -128,9 +128,6 @@ fn is_likely_brotli(data: &[u8]) -> bool {
     decompressor.read_exact(&mut buf).is_ok()
 }
 
-/// Maximum allowed decompressed size (256 MB) to prevent memory exhaustion.
-const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
-
 pub struct DecompressTask {
     data: Vec<u8>,
 }
@@ -144,8 +141,8 @@ impl Task for DecompressTask {
         match detect(&self.data) {
             Format::Zstd => {
                 let capacity = match zstd::zstd_safe::get_frame_content_size(&self.data) {
-                    Ok(Some(size)) => (size as usize).min(MAX_DECOMPRESSED_SIZE),
-                    _ => MAX_DECOMPRESSED_SIZE,
+                    Ok(Some(size)) => (size as usize).min(crate::MAX_DECOMPRESSED_SIZE),
+                    _ => crate::MAX_DECOMPRESSED_SIZE,
                 };
                 let capacity = capacity.max(1024);
                 zstd::bulk::decompress(&self.data, capacity).map_err(|e| {
@@ -158,10 +155,10 @@ impl Task for DecompressTask {
             }
             Format::Gzip => {
                 let decoder = flate2::read::MultiGzDecoder::new(self.data.as_slice());
-                let init_cap = self.data.len().saturating_mul(4).min(MAX_DECOMPRESSED_SIZE);
+                let init_cap = self.data.len().saturating_mul(4).min(crate::MAX_DECOMPRESSED_SIZE);
                 crate::decompress_with_limit(
                     decoder,
-                    MAX_DECOMPRESSED_SIZE,
+                    crate::MAX_DECOMPRESSED_SIZE,
                     init_cap,
                     "gzip decompress",
                 )
@@ -169,10 +166,10 @@ impl Task for DecompressTask {
             Format::Brotli => {
                 let decompressor =
                     brotli::Decompressor::new(self.data.as_slice(), 4096);
-                let init_cap = self.data.len().saturating_mul(4).min(MAX_DECOMPRESSED_SIZE);
+                let init_cap = self.data.len().saturating_mul(4).min(crate::MAX_DECOMPRESSED_SIZE);
                 crate::decompress_with_limit(
                     decompressor,
-                    MAX_DECOMPRESSED_SIZE,
+                    crate::MAX_DECOMPRESSED_SIZE,
                     init_cap,
                     "brotli decompress",
                 )
@@ -180,10 +177,10 @@ impl Task for DecompressTask {
             Format::Lz4 => {
                 let decoder = lz4_flex::frame::FrameDecoder::new(self.data.as_slice());
                 let init_cap =
-                    self.data.len().saturating_mul(4).min(MAX_DECOMPRESSED_SIZE);
+                    self.data.len().saturating_mul(4).min(crate::MAX_DECOMPRESSED_SIZE);
                 crate::decompress_with_limit(
                     decoder,
-                    MAX_DECOMPRESSED_SIZE,
+                    crate::MAX_DECOMPRESSED_SIZE,
                     init_cap,
                     "lz4 decompress",
                 )

--- a/crates/core/src/gzip.rs
+++ b/crates/core/src/gzip.rs
@@ -15,9 +15,6 @@ use crate::ComprsError;
 /// Default compression level for gzip/deflate (flate2 default = 6).
 const DEFAULT_LEVEL: u32 = 6;
 
-/// Maximum allowed decompressed size (256 MB) to prevent memory exhaustion.
-const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
-
 /// Compress data using gzip.
 ///
 /// Returns the compressed data as a Buffer.
@@ -148,7 +145,7 @@ pub fn gzip_read_header(data: Either<Buffer, Uint8Array>) -> Result<GzipHeader> 
 /// for larger data.
 #[napi]
 pub fn gzip_decompress(data: Either<Buffer, Uint8Array>) -> Result<Buffer> {
-    decompress_gzip_with_limit(crate::as_bytes(&data), MAX_DECOMPRESSED_SIZE)
+    decompress_gzip_with_limit(crate::as_bytes(&data), crate::MAX_DECOMPRESSED_SIZE)
 }
 
 /// Decompress gzip-compressed data with explicit capacity.
@@ -207,7 +204,7 @@ pub fn deflate_compress(data: Either<Buffer, Uint8Array>, level: Option<u32>) ->
 /// for larger data.
 #[napi]
 pub fn deflate_decompress(data: Either<Buffer, Uint8Array>) -> Result<Buffer> {
-    decompress_deflate_with_limit(crate::as_bytes(&data), MAX_DECOMPRESSED_SIZE)
+    decompress_deflate_with_limit(crate::as_bytes(&data), crate::MAX_DECOMPRESSED_SIZE)
 }
 
 /// Decompress raw deflate-compressed data with explicit capacity.
@@ -297,8 +294,13 @@ impl Task for GzipDecompressTask {
 
     fn compute(&mut self) -> Result<Self::Output> {
         let decoder = MultiGzDecoder::new(self.data.as_slice());
-        let init_cap = (self.data.len().saturating_mul(4)).min(MAX_DECOMPRESSED_SIZE);
-        crate::decompress_with_limit(decoder, MAX_DECOMPRESSED_SIZE, init_cap, "gzip decompress")
+        let init_cap = (self.data.len().saturating_mul(4)).min(crate::MAX_DECOMPRESSED_SIZE);
+        crate::decompress_with_limit(
+            decoder,
+            crate::MAX_DECOMPRESSED_SIZE,
+            init_cap,
+            "gzip decompress",
+        )
     }
 
     fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
@@ -382,10 +384,10 @@ impl Task for DeflateDecompressTask {
 
     fn compute(&mut self) -> Result<Self::Output> {
         let decoder = DeflateDecoder::new(self.data.as_slice());
-        let init_cap = (self.data.len().saturating_mul(4)).min(MAX_DECOMPRESSED_SIZE);
+        let init_cap = (self.data.len().saturating_mul(4)).min(crate::MAX_DECOMPRESSED_SIZE);
         crate::decompress_with_limit(
             decoder,
-            MAX_DECOMPRESSED_SIZE,
+            crate::MAX_DECOMPRESSED_SIZE,
             init_cap,
             "deflate decompress",
         )

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -20,7 +20,7 @@ use napi_derive::napi;
 pub use error::ComprsError;
 
 /// Maximum allowed decompressed size (256 MB) to prevent memory exhaustion.
-const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
+pub(crate) const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
 
 /// Extract byte slice from Either<Buffer, Uint8Array>.
 fn as_bytes(data: &Either<Buffer, Uint8Array>) -> &[u8] {

--- a/crates/core/src/lz4.rs
+++ b/crates/core/src/lz4.rs
@@ -9,9 +9,6 @@ use napi_derive::napi;
 
 use crate::ComprsError;
 
-/// Maximum allowed decompressed size (256 MB) to prevent memory exhaustion.
-const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
-
 /// Compress data using LZ4 frame format.
 ///
 /// Returns the compressed data as a Buffer.
@@ -46,9 +43,17 @@ pub fn lz4_compress(data: Either<Buffer, Uint8Array>) -> Result<Buffer> {
 pub fn lz4_decompress(data: Either<Buffer, Uint8Array>) -> Result<Buffer> {
     let input = crate::as_bytes(&data);
     let decoder = FrameDecoder::new(input);
-    let init_cap = input.len().saturating_mul(4).min(MAX_DECOMPRESSED_SIZE);
-    crate::decompress_with_limit(decoder, MAX_DECOMPRESSED_SIZE, init_cap, "lz4 decompress")
-        .map(|v| v.into())
+    let init_cap = input
+        .len()
+        .saturating_mul(4)
+        .min(crate::MAX_DECOMPRESSED_SIZE);
+    crate::decompress_with_limit(
+        decoder,
+        crate::MAX_DECOMPRESSED_SIZE,
+        init_cap,
+        "lz4 decompress",
+    )
+    .map(|v| v.into())
 }
 
 /// Decompress LZ4 frame-compressed data with explicit capacity.
@@ -121,8 +126,17 @@ impl Task for Lz4DecompressTask {
 
     fn compute(&mut self) -> Result<Self::Output> {
         let decoder = FrameDecoder::new(self.data.as_slice());
-        let init_cap = self.data.len().saturating_mul(4).min(MAX_DECOMPRESSED_SIZE);
-        crate::decompress_with_limit(decoder, MAX_DECOMPRESSED_SIZE, init_cap, "lz4 decompress")
+        let init_cap = self
+            .data
+            .len()
+            .saturating_mul(4)
+            .min(crate::MAX_DECOMPRESSED_SIZE);
+        crate::decompress_with_limit(
+            decoder,
+            crate::MAX_DECOMPRESSED_SIZE,
+            init_cap,
+            "lz4 decompress",
+        )
     }
 
     fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {

--- a/crates/core/src/zstd.rs
+++ b/crates/core/src/zstd.rs
@@ -9,9 +9,6 @@ use crate::ComprsError;
 /// Default compression level for zstd (same as the C library default).
 const DEFAULT_LEVEL: i32 = 3;
 
-/// Maximum allowed decompressed size (256 MB) to prevent memory exhaustion.
-const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
-
 /// Compress data using Zstandard.
 ///
 /// Returns the compressed data as a Buffer.
@@ -98,8 +95,8 @@ impl Task for ZstdDecompressTask {
 
     fn compute(&mut self) -> Result<Self::Output> {
         let capacity = match zstd::zstd_safe::get_frame_content_size(&self.data) {
-            Ok(Some(size)) => (size as usize).min(MAX_DECOMPRESSED_SIZE),
-            _ => MAX_DECOMPRESSED_SIZE,
+            Ok(Some(size)) => (size as usize).min(crate::MAX_DECOMPRESSED_SIZE),
+            _ => crate::MAX_DECOMPRESSED_SIZE,
         };
         let capacity = capacity.max(1024);
 
@@ -139,8 +136,8 @@ pub fn zstd_decompress(data: Either<Buffer, Uint8Array>) -> Result<Buffer> {
 
     // Try to read the frame content size from the header
     let capacity = match zstd::zstd_safe::get_frame_content_size(input) {
-        Ok(Some(size)) => (size as usize).min(MAX_DECOMPRESSED_SIZE),
-        _ => MAX_DECOMPRESSED_SIZE,
+        Ok(Some(size)) => (size as usize).min(crate::MAX_DECOMPRESSED_SIZE),
+        _ => crate::MAX_DECOMPRESSED_SIZE,
     };
 
     // Use at least 1KB initial capacity
@@ -263,8 +260,8 @@ pub fn zstd_decompress_with_dict(
     let dict_bytes = crate::as_bytes(&dict);
 
     let capacity = match zstd::zstd_safe::get_frame_content_size(input) {
-        Ok(Some(size)) => (size as usize).min(MAX_DECOMPRESSED_SIZE),
-        _ => MAX_DECOMPRESSED_SIZE,
+        Ok(Some(size)) => (size as usize).min(crate::MAX_DECOMPRESSED_SIZE),
+        _ => crate::MAX_DECOMPRESSED_SIZE,
     };
     let capacity = capacity.max(1024);
 
@@ -432,8 +429,8 @@ impl Task for ZstdDecompressWithDictTask {
 
     fn compute(&mut self) -> Result<Self::Output> {
         let capacity = match zstd::zstd_safe::get_frame_content_size(&self.data) {
-            Ok(Some(size)) => (size as usize).min(MAX_DECOMPRESSED_SIZE),
-            _ => MAX_DECOMPRESSED_SIZE,
+            Ok(Some(size)) => (size as usize).min(crate::MAX_DECOMPRESSED_SIZE),
+            _ => crate::MAX_DECOMPRESSED_SIZE,
         };
         let capacity = capacity.max(1024);
 


### PR DESCRIPTION
## Summary

- Remove duplicated `MAX_DECOMPRESSED_SIZE` constant definitions from `zstd.rs`, `gzip.rs`, `brotli_impl.rs`, `lz4.rs`, and `detect.rs`
- Change the canonical definition in `lib.rs` from `const` to `pub(crate) const`
- All modules now reference `crate::MAX_DECOMPRESSED_SIZE` instead of maintaining their own copies

This is a pure refactor with no behavior change.

Closes #209

## Checklist

- [x] `cargo test` — 58 tests pass
- [x] `cargo clippy -- -W clippy::all` — clean
- [x] `pnpm test` — 429 tests pass
- [x] No changeset needed (internal refactor, no public API change)