### PR TITLE
docs: add brotli dictionary to README and update Node.js transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ const compressed = zstdCompressWithDict(data, dict);
 const decompressed = zstdDecompressWithDict(compressed, dict);
 ```
 
+```typescript
+// Brotli dictionary (no training step — provide raw dictionary bytes)
+import { brotliCompressWithDict, brotliDecompressWithDict } from 'comprs';
+
+const dict = Buffer.from('{"id":0,"name":"","email":"@example.com"}'.repeat(10));
+const compressed = brotliCompressWithDict(data, dict);
+const decompressed = brotliDecompressWithDict(compressed, dict);
+```
+
 ## API
 
 ### One-shot
@@ -196,6 +205,14 @@ const decompressed = zstdDecompressWithDict(compressed, dict);
 | `zstdCompressWithDict(data, dict, level?)` | Compress with pre-trained dictionary |
 | `zstdDecompressWithDict(data, dict)` | Decompress dictionary-compressed data |
 
+#### Brotli Dictionary
+
+| Function | Description |
+| --- | --- |
+| `brotliCompressWithDict(data, dict, quality?)` | Compress with custom dictionary |
+| `brotliDecompressWithDict(data, dict)` | Decompress dictionary-compressed data |
+| `brotliDecompressWithDictWithCapacity(data, dict, capacity)` | Decompress with explicit capacity |
+
 ### Async
 
 All compression and decompression functions have async variants (suffix `Async`) that run on the libuv thread pool, keeping the event loop free:
@@ -210,6 +227,8 @@ All compression and decompression functions have async variants (suffix `Async`)
 | `deflateDecompressAsync(data)` | Async deflate decompression |
 | `brotliCompressAsync(data, quality?)` | Async brotli compression |
 | `brotliDecompressAsync(data)` | Async brotli decompression |
+| `brotliCompressWithDictAsync(data, dict, quality?)` | Async brotli compression with dictionary |
+| `brotliDecompressWithDictAsync(data, dict)` | Async brotli decompression with dictionary |
 | `lz4CompressAsync(data)` | Async LZ4 compression |
 | `lz4DecompressAsync(data)` | Async LZ4 decompression |
 
@@ -229,6 +248,8 @@ All compression and decompression functions have async variants (suffix `Async`)
 | `createLz4DecompressStream()` | Create an LZ4 decompression `TransformStream` |
 | `createZstdCompressDictStream(dict, level?)` | Streaming zstd compression with dictionary |
 | `createZstdDecompressDictStream(dict)` | Streaming zstd decompression with dictionary |
+| `createBrotliCompressDictStream(dict, quality?)` | Streaming brotli compression with dictionary |
+| `createBrotliDecompressDictStream(dict)` | Streaming brotli decompression with dictionary |
 | `createDecompressStream()` | Auto-detect format and create a decompression `TransformStream` |
 
 ### Node.js Transform Streams
@@ -261,6 +282,8 @@ await pipeline(
 | `createLz4DecompressTransform()` | Node.js Transform for LZ4 decompression |
 | `createZstdCompressDictTransform(dict, level?)` | Node.js Transform for zstd dict compression |
 | `createZstdDecompressDictTransform(dict)` | Node.js Transform for zstd dict decompression |
+| `createBrotliCompressDictTransform(dict, quality?)` | Node.js Transform for brotli dict compression |
+| `createBrotliDecompressDictTransform(dict)` | Node.js Transform for brotli dict decompression |
 | `createDecompressTransform()` | Auto-detect format and create a decompression Transform |
 
 ## Supported Algorithms
@@ -319,6 +342,7 @@ const decompressed = gzipDecompress(compressed);
 | Deno/Bun | ✅ | ✅ | ✅ | ❌ |
 | Native performance | ✅ | ❌ | ❌ | ✅ |
 | TypeScript | ✅ | ✅ | ✅ | ✅ |
+| Dictionary | ✅ (zstd + brotli) | ❌ | ❌ | ❌ |
 | Zero JS deps | ✅ | ✅ | ✅ | ✅ |
 
 \* Node.js ≥ 22.15 (experimental)

--- a/__test__/esm-import.mjs
+++ b/__test__/esm-import.mjs
@@ -1,13 +1,22 @@
 import assert from 'node:assert';
 import {
+  BrotliCompressDictContext,
+  BrotliDecompressDictContext,
   brotliCompress,
   brotliCompressAsync,
+  brotliCompressWithDict,
+  brotliCompressWithDictAsync,
   brotliDecompress,
   brotliDecompressAsync,
   brotliDecompressWithCapacity,
   brotliDecompressWithCapacityAsync,
+  brotliDecompressWithDict,
+  brotliDecompressWithDictAsync,
+  brotliDecompressWithDictWithCapacity,
   crc32,
+  createBrotliCompressDictStream,
   createBrotliCompressStream,
+  createBrotliDecompressDictStream,
   createBrotliDecompressStream,
   createDecompressStream,
   createDeflateCompressStream,
@@ -221,6 +230,51 @@ assert.strictEqual(
   typeof createBrotliDecompressStream,
   'function',
   'createBrotliDecompressStream should be a function',
+);
+assert.strictEqual(
+  typeof brotliCompressWithDict,
+  'function',
+  'brotliCompressWithDict should be a function',
+);
+assert.strictEqual(
+  typeof brotliCompressWithDictAsync,
+  'function',
+  'brotliCompressWithDictAsync should be a function',
+);
+assert.strictEqual(
+  typeof brotliDecompressWithDict,
+  'function',
+  'brotliDecompressWithDict should be a function',
+);
+assert.strictEqual(
+  typeof brotliDecompressWithDictAsync,
+  'function',
+  'brotliDecompressWithDictAsync should be a function',
+);
+assert.strictEqual(
+  typeof brotliDecompressWithDictWithCapacity,
+  'function',
+  'brotliDecompressWithDictWithCapacity should be a function',
+);
+assert.strictEqual(
+  typeof BrotliCompressDictContext,
+  'function',
+  'BrotliCompressDictContext should be a function',
+);
+assert.strictEqual(
+  typeof BrotliDecompressDictContext,
+  'function',
+  'BrotliDecompressDictContext should be a function',
+);
+assert.strictEqual(
+  typeof createBrotliCompressDictStream,
+  'function',
+  'createBrotliCompressDictStream should be a function',
+);
+assert.strictEqual(
+  typeof createBrotliDecompressDictStream,
+  'function',
+  'createBrotliDecompressDictStream should be a function',
 );
 assert.strictEqual(typeof lz4Compress, 'function', 'lz4Compress should be a function');
 assert.strictEqual(typeof lz4Decompress, 'function', 'lz4Decompress should be a function');

--- a/node.d.ts
+++ b/node.d.ts
@@ -128,6 +128,34 @@ export declare function createZstdDecompressDictTransform(
 ): Transform;
 
 /**
+ * Create a Node.js stream.Transform for brotli compression with a custom dictionary.
+ *
+ * Uses Node.js `stream.Transform` to provide chunked compression with a custom
+ * dictionary, compatible with `stream.pipeline()` and pipe-based workflows.
+ *
+ * @param dict Custom dictionary bytes.
+ * @param quality Compression quality (0-11). Default is 6.
+ */
+export declare function createBrotliCompressDictTransform(
+  dict: Buffer | Uint8Array,
+  quality?: number,
+): Transform;
+
+/**
+ * Create a Node.js stream.Transform for brotli decompression with a custom dictionary.
+ *
+ * Uses Node.js `stream.Transform` to provide chunked decompression with a custom
+ * dictionary, compatible with `stream.pipeline()` and pipe-based workflows.
+ *
+ * @param dict Custom dictionary (must match the one used for compression).
+ * @param maxOutputSize Maximum decompressed output size in bytes. Default is 256 MB.
+ */
+export declare function createBrotliDecompressDictTransform(
+  dict: Buffer | Uint8Array,
+  maxOutputSize?: number,
+): Transform;
+
+/**
  * Create a Node.js stream.Transform for auto-detect decompression.
  *
  * Detects the compression format (zstd, gzip, brotli, or lz4) from the first

--- a/node.js
+++ b/node.js
@@ -10,6 +10,8 @@ const {
   DeflateDecompressContext,
   BrotliCompressContext,
   BrotliDecompressContext,
+  BrotliCompressDictContext,
+  BrotliDecompressDictContext,
   Lz4CompressContext,
   Lz4DecompressContext,
   detectFormat,
@@ -331,6 +333,70 @@ function createZstdDecompressDictTransform(dict, maxOutputSize) {
   });
 }
 
+/**
+ * Create a Node.js stream.Transform for brotli compression with a custom dictionary.
+ *
+ * @param {Buffer | Uint8Array} dict Custom dictionary
+ * @param {number} [quality=6] Compression quality (0-11)
+ * @returns {Transform}
+ */
+function createBrotliCompressDictTransform(dict, quality) {
+  const ctx = new BrotliCompressDictContext(dict, quality);
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      try {
+        const result = ctx.transform(chunk);
+        if (result.byteLength > 0) this.push(result);
+        callback();
+      } catch (err) {
+        callback(err);
+      }
+    },
+    flush(callback) {
+      try {
+        const flushed = ctx.flush();
+        if (flushed.byteLength > 0) this.push(flushed);
+        const finished = ctx.finish();
+        if (finished.byteLength > 0) this.push(finished);
+        callback();
+      } catch (err) {
+        callback(err);
+      }
+    },
+  });
+}
+
+/**
+ * Create a Node.js stream.Transform for brotli decompression with a custom dictionary.
+ *
+ * @param {Buffer | Uint8Array} dict Custom dictionary (must match the one used for compression)
+ * @param {number} [maxOutputSize] Maximum decompressed output size in bytes
+ * @returns {Transform}
+ */
+function createBrotliDecompressDictTransform(dict, maxOutputSize) {
+  const ctx = new BrotliDecompressDictContext(dict, maxOutputSize);
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      try {
+        const result = ctx.transform(chunk);
+        if (result.byteLength > 0) this.push(result);
+        callback();
+      } catch (err) {
+        callback(err);
+      }
+    },
+    flush(callback) {
+      try {
+        const flushed = ctx.flush();
+        if (flushed.byteLength > 0) this.push(flushed);
+        callback();
+      } catch (err) {
+        callback(err);
+      }
+    },
+  });
+}
+
 function createDecompressContext(format, maxOutputSize) {
   switch (format) {
     case 'zstd':
@@ -486,6 +552,8 @@ module.exports = {
   createDeflateDecompressTransform,
   createBrotliCompressTransform,
   createBrotliDecompressTransform,
+  createBrotliCompressDictTransform,
+  createBrotliDecompressDictTransform,
   createLz4CompressTransform,
   createLz4DecompressTransform,
   createDecompressTransform,


### PR DESCRIPTION
## Summary

- Add brotli dictionary compression examples and API tables to README.md (one-shot, async, streaming, Node.js Transform, comparison table)
- Add `createBrotliCompressDictTransform` and `createBrotliDecompressDictTransform` to `node.js` / `node.d.ts`
- Add brotli dictionary imports and assertions to `__test__/esm-import.mjs`

Closes #227

## Test plan

- [x] `cargo test` — 59 passed
- [x] `cargo clippy -- -W clippy::all` — clean
- [x] `pnpm run check` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm test` — 440 passed