### PR TITLE
docs: add known limitations and performance notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,20 @@ Benchmarks run on Apple M2, Node.js v22. Run locally with `pnpm run bench`. Numb
 - **brotli compression**: comprs is 10--155x faster than `node:zlib` thanks to the Rust brotli implementation
 - **Native vs WASM**: these numbers are from the native (napi-rs) backend; WASM throughput is lower due to the execution overhead but still outperforms pure-JS libraries on large payloads
 
+## Notes
+
+> [!NOTE]
+> **Default decompression limit**: All decompression functions cap output at 256 MB by default. Use `*WithCapacity()` variants for larger data:
+> ```typescript
+> const decompressed = zstdDecompressWithCapacity(data, 1024 * 1024 * 1024); // 1 GB
+> ```
+
+> [!NOTE]
+> **Small payloads on WASM**: For data under ~1 KB, the WASM runtime overhead may exceed compression time. Consider batching small items or using the native Node.js backend where possible.
+
+> [!NOTE]
+> **Brotli decompression**: While comprs brotli *compression* is 10–155x faster than `node:zlib`, decompression performance varies by data type and size. For decompression-heavy workloads on Node.js, benchmark your specific data.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.


### PR DESCRIPTION
## Summary

- Add "Notes" section before Contributing with three GitHub admonitions:
  - 256 MB default decompression limit with `*WithCapacity()` workaround example
  - Small payload (~1 KB) WASM overhead advisory
  - Brotli decompression performance nuance vs `node:zlib`

## Related issue

Closes #238

## Checklist

- [x] README-only change
- [x] All pre-push checks pass
- [x] Claims verified against actual benchmark data in README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * READMEに「Notes」セクションを追加。デコンプレッション関数のデフォルト出力上限（256 MB）の説明、WASMでのパフォーマンス最適化に関する考慮事項、およびブロトリデコンプレッションのパフォーマンス特性に関する運用上のガイダンスが記載されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->