### PR TITLE
docs: add benchmark comparison SVG charts

### DIFF
--- a/.github/assets/bench-brotli.svg
+++ b/.github/assets/bench-brotli.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 150" width="680" height="150">
+<style>
+  text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+  .title { font-size: 16px; font-weight: 600; fill: #1f2937; }
+  .subtitle { font-size: 12px; fill: #6b7280; }
+  .bar-label { font-size: 12px; fill: #4b5563; }
+  .bar-value { font-size: 12px; fill: #374151; font-weight: 500; }
+  .multiplier { font-size: 11px; fill: #059669; font-weight: 600; }
+</style>
+<rect width="680" height="150" rx="8" fill="#ffffff" />
+<rect x="0.5" y="0.5" width="679" height="149" rx="8" fill="none" stroke="#e5e7eb" />
+<text x="20" y="28" class="title">Brotli Compression — 10 KB random</text>
+<text x="20" y="44" class="subtitle">Apple M2 · Node.js v22 · ops/sec (higher is better)</text>
+<text x="112" y="78" class="bar-label" text-anchor="end">comprs</text>
+<rect x="120" y="60" width="360" height="28" rx="4" fill="#a855f7" />
+<text x="488" y="78" class="bar-value">8,188 ops/s</text>
+<text x="112" y="114" class="bar-label" text-anchor="end">node:zlib</text>
+<rect x="120" y="96" width="2.7" height="28" rx="1" fill="#94a3b8" opacity="0.65" />
+<text x="131" y="114" class="bar-value">61 ops/s</text>
+<text x="210" y="114" class="multiplier">134.7x faster</text>
+</svg>

--- a/.github/assets/bench-cross-algorithm.svg
+++ b/.github/assets/bench-cross-algorithm.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 220" width="680" height="220">
+<style>
+  text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+  .title { font-size: 16px; font-weight: 600; fill: #1f2937; }
+  .subtitle { font-size: 12px; fill: #6b7280; }
+  .bar-label { font-size: 12px; fill: #4b5563; }
+  .bar-value { font-size: 12px; fill: #374151; font-weight: 500; }
+  .multiplier { font-size: 11px; fill: #6b7280; font-style: italic; }
+</style>
+<rect width="680" height="220" rx="8" fill="#ffffff" />
+<rect x="0.5" y="0.5" width="679" height="219" rx="8" fill="none" stroke="#e5e7eb" />
+<text x="20" y="28" class="title">Cross-Algorithm Compression — 10 KB</text>
+<text x="20" y="44" class="subtitle">Apple M2 · Node.js v22 · ops/sec (higher is better)</text>
+<text x="112" y="78" class="bar-label" text-anchor="end">lz4</text>
+<rect x="120" y="60" width="360" height="28" rx="4" fill="#22c55e" />
+<text x="488" y="78" class="bar-value">165,821 ops/s</text>
+<text x="112" y="114" class="bar-label" text-anchor="end">zstd</text>
+<rect x="120" y="96" width="351" height="28" rx="4" fill="#3b82f6" />
+<text x="479" y="114" class="bar-value">161,706 ops/s</text>
+<text x="112" y="150" class="bar-label" text-anchor="end">gzip</text>
+<rect x="120" y="132" width="69" height="28" rx="4" fill="#f59e0b" />
+<text x="197" y="150" class="bar-value">31,941 ops/s</text>
+<text x="112" y="186" class="bar-label" text-anchor="end">brotli</text>
+<rect x="120" y="168" width="33" height="28" rx="4" fill="#a855f7" />
+<text x="161" y="186" class="bar-value">15,146 ops/s</text>
+<text x="260" y="186" class="multiplier">best compression ratio</text>
+</svg>

--- a/README.md
+++ b/README.md
@@ -475,7 +475,11 @@ comprs adds zstd, lz4, brotli, dictionary compression, and Web Streams API — n
 
 ## Benchmarks
 
-<img src=".github/assets/bench-compress.svg" alt="Compression benchmark chart" width="680" />
+<img src=".github/assets/bench-cross-algorithm.svg" alt="Cross-algorithm compression benchmark" width="680" />
+
+<img src=".github/assets/bench-compress.svg" alt="Gzip compression benchmark chart" width="680" />
+
+<img src=".github/assets/bench-brotli.svg" alt="Brotli compression benchmark chart" width="680" />
 
 Benchmarks run on Apple M2, Node.js v22. Run locally with `pnpm run bench`. Numbers vary by machine and data type.
 


### PR DESCRIPTION
## Summary

- Add cross-algorithm compression chart (`bench-cross-algorithm.svg`) showing lz4/zstd/gzip/brotli relative performance at 10KB
- Add brotli compression speedup chart (`bench-brotli.svg`) showing 134.7x improvement over node:zlib at 10KB random
- Embed both new charts alongside existing gzip chart in Benchmarks section
- Charts follow existing SVG design language (same fonts, colors, layout)

## Related issue

Closes #230

## Checklist

- [x] SVG charts visually verified in Chrome
- [x] All pre-push checks pass
- [x] Benchmark data matches README tables