### PR TITLE
docs: fold repetitive API tables into collapsible sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,9 @@ import { gzipCompress } from 'comprs';
 | `crc32(data, initialValue?)` | Compute CRC32 checksum (supports incremental computation) |
 | `version()` | Returns the library version |
 
+<details>
+<summary><strong>Dictionary API</strong></summary>
+
 #### zstd Dictionary
 
 | Function | Description |
@@ -272,9 +275,19 @@ import { gzipCompress } from 'comprs';
 | `brotliDecompressWithDict(data, dict)` | Decompress dictionary-compressed data |
 | `brotliDecompressWithDictWithCapacity(data, dict, capacity)` | Decompress with explicit capacity |
 
+</details>
+
 ### Async
 
-All compression and decompression functions have async variants (suffix `Async`) that run on the libuv thread pool, keeping the event loop free:
+All one-shot functions have async variants that run on the libuv thread pool. Append `Async` to any function name:
+
+```typescript
+const compressed = await zstdCompressAsync(data, level);
+const decompressed = await gzipDecompressAsync(compressed);
+```
+
+<details>
+<summary><strong>Full async API list</strong></summary>
 
 | Function | Description |
 | --- | --- |
@@ -300,7 +313,18 @@ All compression and decompression functions have async variants (suffix `Async`)
 | `lz4DecompressWithCapacityAsync(data, capacity)` | Async LZ4 decompression with explicit size limit |
 | `decompressAsync(data)` | Async auto-detect format and decompress |
 
+</details>
+
 ### Streaming
+
+Web Streams API (`TransformStream`) for all algorithms. Import from `comprs/streams`:
+
+```typescript
+import { createGzipCompressStream } from 'comprs/streams';
+```
+
+<details>
+<summary><strong>Full streaming API list</strong></summary>
 
 | Function | Description |
 | --- | --- |
@@ -320,6 +344,8 @@ All compression and decompression functions have async variants (suffix `Async`)
 | `createBrotliDecompressDictStream(dict)` | Streaming brotli decompression with dictionary |
 | `createDecompressStream()` | Auto-detect format and create a decompression `TransformStream` |
 
+</details>
+
 ### Node.js Transform Streams
 
 For Node.js `stream.pipeline()` compatibility, import from `comprs/node`:
@@ -335,6 +361,9 @@ await pipeline(
   createWriteStream('output.gz'),
 );
 ```
+
+<details>
+<summary><strong>Full Node.js Transform API list</strong></summary>
 
 | Function | Description |
 | --- | --- |
@@ -353,6 +382,8 @@ await pipeline(
 | `createBrotliCompressDictTransform(dict, quality?)` | Node.js Transform for brotli dict compression |
 | `createBrotliDecompressDictTransform(dict)` | Node.js Transform for brotli dict decompression |
 | `createDecompressTransform()` | Auto-detect format and create a decompression Transform |
+
+</details>
 
 ## Supported Algorithms
 


### PR DESCRIPTION
## Summary

- Wrap Dictionary API tables (zstd + brotli) in `<details>`
- Replace Async section header with concise pattern explanation + code example, fold full 21-row table into `<details>`
- Add Streaming one-line import example, fold full table into `<details>`
- Keep Node.js Transform `pipeline()` code example visible, fold 15-row table into `<details>`
- One-shot core tables (zstd, gzip/deflate, brotli, lz4, auto-detect, utilities) remain fully visible as the primary reference

Reduces visible API section from ~153 lines to ~75 lines while preserving all information in collapsible sections.

## Related issue

Closes #249

## Checklist

- [x] README-only change
- [x] All pre-push checks pass
- [x] No information removed — only folded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * API ドキュメントを再編成し、関数リストをコラプシブルセクションで整理しました。
  * Async セクションに `Async` サフィックスの付与方法と使用例を追加。
  * Streaming セクションに Web Streams API の説明とインポート例を追加。
  * Node.js Transform Streams セクションを更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->