### PR TITLE
feat: add interactive playground with GitHub Pages deployment

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -1,0 +1,90 @@
+name: Deploy Playground
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'playground/**'
+      - '.github/workflows/playground.yml'
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'browser-entry.js'
+      - 'browser-streaming.js'
+      - 'browser.js'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    name: Build and deploy playground
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: stable
+          targets: wasm32-wasip1-threads
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: playground-wasm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup WASI SDK
+        run: |
+          WASI_SDK_VERSION="25"
+          WASI_SDK_DIR="wasi-sdk-${WASI_SDK_VERSION}.0-x86_64-linux"
+          curl -fsSL "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION}/${WASI_SDK_DIR}.tar.gz" | tar xz -C "${RUNNER_TEMP}"
+          echo "WASI_SDK_PATH=${RUNNER_TEMP}/${WASI_SDK_DIR}" >> $GITHUB_ENV
+          echo "WASI_SYSROOT=${RUNNER_TEMP}/${WASI_SDK_DIR}/share/wasi-sysroot" >> $GITHUB_ENV
+          echo "CC_wasm32_wasip1_threads=${RUNNER_TEMP}/${WASI_SDK_DIR}/bin/clang" >> $GITHUB_ENV
+          echo "AR_wasm32_wasip1_threads=${RUNNER_TEMP}/${WASI_SDK_DIR}/bin/llvm-ar" >> $GITHUB_ENV
+
+      - name: Build WASM
+        run: |
+          export CFLAGS_wasm32_wasip1_threads="--sysroot=${WASI_SYSROOT}"
+          pnpm run build:wasm
+
+      - name: Optimize WASM
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -q binaryen
+          pnpm run optimize:wasm
+
+      - name: Install playground dependencies
+        run: cd playground && pnpm install
+
+      - name: Build playground
+        run: cd playground && pnpm build
+        env:
+          GITHUB_ACTIONS: true
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: playground/dist
+
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Rust-powered universal compression for JavaScript/TypeScript.
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-ready-blue)](https://www.typescriptlang.org/)
+[![Playground](https://img.shields.io/badge/playground-try%20it%20live-8b5cf6)](https://derodero24.github.io/comprs/)
 
 </div>
 
@@ -75,6 +76,8 @@ bun add comprs
 ```
 
 ## Quick Start
+
+> **Try it live** → [derodero24.github.io/comprs](https://derodero24.github.io/comprs/)
 
 ```typescript
 import { zstdCompress, zstdDecompress } from 'comprs';

--- a/biome.json
+++ b/biome.json
@@ -105,6 +105,31 @@
       }
     },
     {
+      "includes": ["playground/vite.config.js"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noDefaultExport": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["playground/public/coi-serviceworker.js"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off",
+            "useIterableCallbackReturn": "off"
+          },
+          "complexity": {
+            "noForEach": "off",
+            "useOptionalChain": "off"
+          }
+        }
+      }
+    },
+    {
       "includes": ["index.d.mts"],
       "linter": {
         "rules": {

--- a/playground/comprs-mock.js
+++ b/playground/comprs-mock.js
@@ -1,0 +1,320 @@
+/**
+ * Development mock for comprs-wasm32-wasi.
+ * Provides realistic fake compression ratios using native browser APIs where possible.
+ * Used only when no local WASM build is available.
+ */
+
+// Use native CompressionStream for gzip (realistic results)
+async function _compressWithNative(data, format) {
+  const cs = new CompressionStream(format);
+  const writer = cs.writable.getWriter();
+  writer.write(data);
+  writer.close();
+  const chunks = [];
+  const reader = cs.readable.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  const total = chunks.reduce((n, c) => n + c.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
+// Simple fake: return a plausible compressed size with a magic header
+function fakeCompress(data, ratio, magicHeader) {
+  const compressedSize = Math.max(8, Math.floor(data.length * ratio));
+  const out = new Uint8Array(compressedSize);
+  // Write magic bytes at the start
+  for (let i = 0; i < Math.min(magicHeader.length, out.length); i++) {
+    out[i] = magicHeader[i];
+  }
+  return out;
+}
+
+function fakeDecompress(data, originalData) {
+  return originalData ?? new Uint8Array(data.length * 3);
+}
+
+// Cache for original data (needed for fake round-trips)
+const cache = new WeakMap();
+
+export function zstdCompress(data, level = 3) {
+  const ratio = Math.max(0.2, 0.65 - (level - 1) * 0.02);
+  const out = fakeCompress(data, ratio, [0x28, 0xb5, 0x2f, 0xfd]); // zstd magic
+  cache.set(out, data);
+  return out;
+}
+export function zstdDecompress(data) {
+  return fakeDecompress(data, cache.get(data));
+}
+export function zstdDecompressWithCapacity(data) {
+  return zstdDecompress(data);
+}
+export function zstdCompressAsync(data, level) {
+  return Promise.resolve(zstdCompress(data, level));
+}
+export function zstdDecompressAsync(data) {
+  return Promise.resolve(zstdDecompress(data));
+}
+
+// gzip: use native CompressionStream for realistic results
+const _gzipCache = null;
+export function gzipCompress(data, level = 6) {
+  // Sync approximation
+  const ratio = Math.max(0.25, 0.7 - level * 0.02);
+  const out = fakeCompress(data, ratio, [0x1f, 0x8b]); // gzip magic
+  cache.set(out, data);
+  return out;
+}
+export function gzipDecompress(data) {
+  return fakeDecompress(data, cache.get(data));
+}
+export function gzipDecompressWithCapacity(data) {
+  return gzipDecompress(data);
+}
+export function gzipCompressAsync(data, level) {
+  return Promise.resolve(gzipCompress(data, level));
+}
+export function gzipDecompressAsync(data) {
+  return Promise.resolve(gzipDecompress(data));
+}
+export function gzipCompressWithHeader(data, _header, level) {
+  return gzipCompress(data, level);
+}
+export function gzipReadHeader(_data) {
+  return {};
+}
+
+export function brotliCompress(data, quality = 6) {
+  const ratio = Math.max(0.18, 0.6 - quality * 0.025);
+  const out = fakeCompress(data, ratio, [0x0b, 0x05]); // brotli-ish
+  cache.set(out, data);
+  return out;
+}
+export function brotliDecompress(data) {
+  return fakeDecompress(data, cache.get(data));
+}
+export function brotliDecompressWithCapacity(data) {
+  return brotliDecompress(data);
+}
+export function brotliCompressAsync(data, q) {
+  return Promise.resolve(brotliCompress(data, q));
+}
+export function brotliDecompressAsync(data) {
+  return Promise.resolve(brotliDecompress(data));
+}
+export function brotliCompressWithDict(data, _dict, quality) {
+  return brotliCompress(data, quality);
+}
+export function brotliDecompressWithDict(data, _dict) {
+  return brotliDecompress(data);
+}
+export function brotliCompressWithDictAsync(data, _dict, q) {
+  return brotliCompressAsync(data, q);
+}
+export function brotliDecompressWithDictAsync(data, _dict) {
+  return brotliDecompressAsync(data);
+}
+export function brotliDecompressWithDictWithCapacity(data, _dict) {
+  return brotliDecompress(data);
+}
+export function brotliDecompressWithDictWithCapacityAsync(data, _dict) {
+  return Promise.resolve(brotliDecompress(data));
+}
+
+export function deflateCompress(data, level = 6) {
+  const ratio = Math.max(0.25, 0.68 - level * 0.02);
+  const out = fakeCompress(data, ratio, [0x78, 0x9c]);
+  cache.set(out, data);
+  return out;
+}
+export function deflateDecompress(data) {
+  return fakeDecompress(data, cache.get(data));
+}
+export function deflateDecompressWithCapacity(data) {
+  return deflateDecompress(data);
+}
+export function deflateCompressAsync(data, level) {
+  return Promise.resolve(deflateCompress(data, level));
+}
+export function deflateDecompressAsync(data) {
+  return Promise.resolve(deflateDecompress(data));
+}
+
+export function lz4Compress(data) {
+  const ratio = 0.55;
+  const out = fakeCompress(data, ratio, [0x04, 0x22, 0x4d, 0x18]); // lz4 magic
+  cache.set(out, data);
+  return out;
+}
+export function lz4Decompress(data) {
+  return fakeDecompress(data, cache.get(data));
+}
+export function lz4DecompressWithCapacity(data) {
+  return lz4Decompress(data);
+}
+export function lz4CompressAsync(data) {
+  return Promise.resolve(lz4Compress(data));
+}
+export function lz4DecompressAsync(data) {
+  return Promise.resolve(lz4Decompress(data));
+}
+
+export function decompress(data) {
+  return data;
+}
+export function decompressAsync(data) {
+  return Promise.resolve(data);
+}
+export function detectFormat(_data) {
+  return 'unknown';
+}
+export function crc32(_data) {
+  return 0;
+}
+export function version() {
+  return '0.3.1-mock';
+}
+export function zstdTrainDictionary(_samples, _maxSize) {
+  return new Uint8Array(0);
+}
+export function zstdTrainDictionaryAsync(_samples, _maxSize) {
+  return Promise.resolve(new Uint8Array(0));
+}
+export function zstdCompressWithDict(data, _dict, level) {
+  return zstdCompress(data, level);
+}
+export function zstdDecompressWithDict(data, _dict) {
+  return zstdDecompress(data);
+}
+export function zstdCompressWithDictAsync(data, _dict, level) {
+  return zstdCompressAsync(data, level);
+}
+export function zstdDecompressWithDictAsync(data, _dict) {
+  return zstdDecompressAsync(data);
+}
+
+export const CompressionFormat = { Zstd: 'zstd', Gzip: 'gzip', Brotli: 'brotli', Lz4: 'lz4' };
+
+// Context stubs (not used in playground)
+export class ZstdCompressContext {
+  transform(c) {
+    return zstdCompress(c);
+  }
+  flush() {
+    return new Uint8Array(0);
+  }
+  finish() {
+    return new Uint8Array(0);
+  }
+}
+export class ZstdDecompressContext {
+  transform(c) {
+    return zstdDecompress(c);
+  }
+  flush() {
+    return new Uint8Array(0);
+  }
+  finish() {
+    return new Uint8Array(0);
+  }
+}
+export class ZstdCompressDictContext extends ZstdCompressContext {}
+export class ZstdDecompressDictContext extends ZstdDecompressContext {}
+export class GzipCompressContext {
+  transform(c) {
+    return gzipCompress(c);
+  }
+  flush() {
+    return new Uint8Array(0);
+  }
+  finish() {
+    return new Uint8Array(0);
+  }
+}
+export class GzipDecompressContext {
+  transform(c) {
+    return gzipDecompress(c);
+  }
+  flush() {
+    return new Uint8Array(0);
+  }
+  finish() {
+    return new Uint8Array(0);
+  }
+}
+export class DeflateCompressContext {
+  transform(c) {
+    return deflateCompress(c);
+  }
+  flush() {
+    return new Uint8Array(0);
+  }
+  finish() {
+    return new Uint8Array(0);
+  }
+}
+export class DeflateDecompressContext {
+  transform(c) {
+    return deflateDecompress(c);
+  }
+  flush() {
+    return new Uint8Array(0);
+  }
+  finish() {
+    return new Uint8Array(0);
+  }
+}
+export class BrotliCompressContext {
+  transform(c) {
+    return brotliCompress(c);
+  }
+  flush() {
+    return new Uint8Array(0);
+  }
+  finish() {
+    return new Uint8Array(0);
+  }
+}
+export class BrotliDecompressContext {
+  transform(c) {
+    return brotliDecompress(c);
+  }
+  flush() {
+    return new Uint8Array(0);
+  }
+  finish() {
+    return new Uint8Array(0);
+  }
+}
+export class BrotliCompressDictContext extends BrotliCompressContext {}
+export class BrotliDecompressDictContext extends BrotliDecompressContext {}
+export class Lz4CompressContext {
+  transform(c) {
+    return lz4Compress(c);
+  }
+  flush() {
+    return new Uint8Array(0);
+  }
+  finish() {
+    return new Uint8Array(0);
+  }
+}
+export class Lz4DecompressContext {
+  transform(c) {
+    return lz4Decompress(c);
+  }
+  flush() {
+    return new Uint8Array(0);
+  }
+  finish() {
+    return new Uint8Array(0);
+  }
+}

--- a/playground/index.html
+++ b/playground/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>comprs Playground</title>
+  <meta name="description" content="Interactive playground for comprs — Rust-powered zstd, gzip, brotli, and lz4 compression for JavaScript.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500&family=Geist:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <script>window.coi = { quiet: true };</script>
+  <script src="/coi-serviceworker.js"></script>
+
+  <header>
+    <div class="header-inner">
+      <div class="header-brand">
+        <span class="header-logo">comprs</span>
+        <span class="badge">Playground</span>
+      </div>
+      <nav class="header-nav">
+        <a href="https://github.com/derodero24/comprs" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://www.npmjs.com/package/comprs" target="_blank" rel="noopener">npm</a>
+        <a href="https://github.com/derodero24/comprs#readme" target="_blank" rel="noopener">Docs</a>
+      </nav>
+    </div>
+    <p class="header-subtitle">Rust-powered compression in the browser — try it live.</p>
+  </header>
+
+  <main>
+    <!-- Input card -->
+    <div class="card" id="input-card">
+      <div class="card-header">
+        <h2 class="card-title">Input</h2>
+        <div class="sample-row">
+          <span class="sample-label">Sample:</span>
+          <button type="button" class="sample-btn active" data-sample="json">JSON</button>
+          <button type="button" class="sample-btn" data-sample="log">Log</button>
+          <button type="button" class="sample-btn" data-sample="lorem">Text</button>
+          <label class="upload-btn" title="Upload a file">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+            File
+            <input type="file" id="file-input">
+          </label>
+        </div>
+      </div>
+      <textarea id="input-text" rows="8" spellcheck="false" placeholder="Enter text to compress…"></textarea>
+      <div class="input-footer">
+        <span class="input-size" id="input-size">0 B</span>
+      </div>
+    </div>
+
+    <!-- Compress card -->
+    <div class="card" id="compress-card">
+      <div class="card-header">
+        <h2 class="card-title">Compress</h2>
+      </div>
+
+      <div class="algo-row">
+        <button type="button" class="algo-btn active" data-algo="zstd">zstd</button>
+        <button type="button" class="algo-btn" data-algo="gzip">gzip</button>
+        <button type="button" class="algo-btn" data-algo="brotli">brotli</button>
+        <button type="button" class="algo-btn" data-algo="lz4">lz4</button>
+      </div>
+
+      <div class="level-row" id="level-row">
+        <label class="level-label">
+          Level
+          <span class="level-value" id="level-display">3</span>
+        </label>
+        <input type="range" id="level-slider" class="slider" min="1" max="22" value="3">
+        <span class="level-hint" id="level-hint">1 = fast, 22 = best ratio</span>
+      </div>
+
+      <div class="result-grid" id="result-grid">
+        <div class="result-box">
+          <div class="result-label">Original</div>
+          <div class="result-value" id="original-size">—</div>
+        </div>
+        <div class="result-arrow">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+        </div>
+        <div class="result-box result-box--accent" id="result-box-right">
+          <div class="result-label">Compressed</div>
+          <div class="result-value" id="compressed-size">—</div>
+          <div class="result-ratio" id="compression-ratio"></div>
+        </div>
+        <div class="result-meta">
+          <div class="result-time" id="compress-time"></div>
+          <button type="button" class="download-btn" id="download-btn" hidden>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+            Download
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Compare card -->
+    <div class="card" id="compare-card">
+      <div class="card-header">
+        <h2 class="card-title">Algorithm Comparison</h2>
+        <span class="card-subtitle">All algorithms on the same input</span>
+      </div>
+      <div class="compare-table" id="compare-table">
+        <div class="compare-placeholder">Enter some text above to see comparisons.</div>
+      </div>
+    </div>
+  </main>
+
+  <footer>
+    <div class="footer-inner">
+      <p>
+        <a href="https://github.com/derodero24/comprs" target="_blank" rel="noopener">GitHub</a>
+        ·
+        <a href="https://www.npmjs.com/package/comprs" target="_blank" rel="noopener">npm</a>
+        ·
+        Rust-powered · Zero JS dependencies
+      </p>
+    </div>
+  </footer>
+
+  <div class="loading-overlay" id="loading-overlay">
+    <div class="loading-inner">
+      <div class="spinner"></div>
+      <p class="loading-text">Loading WASM module…</p>
+    </div>
+  </div>
+
+  <script type="module" src="/main.js"></script>
+</body>
+</html>

--- a/playground/main.js
+++ b/playground/main.js
@@ -1,0 +1,388 @@
+import {
+  brotliCompress,
+  brotliDecompress,
+  gzipCompress,
+  gzipDecompress,
+  lz4Compress,
+  lz4Decompress,
+  zstdCompress,
+  zstdDecompress,
+} from 'comprs';
+
+// --- Sample data ---
+const SAMPLES = {
+  json: JSON.stringify(
+    {
+      users: [
+        { id: 1, name: 'Alice', email: 'alice@example.com', role: 'admin', active: true },
+        { id: 2, name: 'Bob', email: 'bob@example.com', role: 'editor', active: true },
+        { id: 3, name: 'Carol', email: 'carol@example.com', role: 'viewer', active: false },
+        { id: 4, name: 'Dave', email: 'dave@example.com', role: 'editor', active: true },
+        { id: 5, name: 'Eve', email: 'eve@example.com', role: 'admin', active: true },
+      ],
+      pagination: { page: 1, perPage: 20, total: 5, totalPages: 1 },
+      meta: { generatedAt: '2025-01-15T10:23:45Z', version: '2.1.0', requestId: 'req-abc123' },
+    },
+    null,
+    2,
+  ),
+  log: [
+    '2025-01-15T10:23:44.123Z INFO  [server] Starting HTTP server on :8080',
+    '2025-01-15T10:23:44.456Z INFO  [db] Connected to PostgreSQL at localhost:5432',
+    '2025-01-15T10:23:45.001Z INFO  [server] Request: GET /api/users 200 12ms',
+    '2025-01-15T10:23:45.102Z INFO  [server] Request: POST /api/users 201 34ms',
+    '2025-01-15T10:23:45.204Z WARN  [auth] Token expiring soon for user alice@example.com',
+    '2025-01-15T10:23:45.305Z INFO  [server] Request: GET /api/users/1 200 8ms',
+    '2025-01-15T10:23:45.407Z INFO  [db] Query executed in 5ms: SELECT * FROM users WHERE id=1',
+    '2025-01-15T10:23:45.509Z INFO  [server] Request: DELETE /api/sessions/tok-xyz 204 3ms',
+    '2025-01-15T10:23:45.611Z INFO  [server] Request: GET /api/health 200 1ms',
+    '2025-01-15T10:23:45.712Z INFO  [server] Request: GET /api/users 200 11ms',
+    '2025-01-15T10:23:45.814Z ERROR [db] Slow query detected (>100ms): SELECT * FROM audit_log',
+    '2025-01-15T10:23:45.916Z INFO  [server] Request: GET /api/users/2 200 9ms',
+    '2025-01-15T10:23:46.018Z INFO  [cache] Cache miss for key: users:page:1',
+    '2025-01-15T10:23:46.120Z INFO  [db] Query executed in 18ms: SELECT * FROM users LIMIT 20',
+    '2025-01-15T10:23:46.221Z INFO  [cache] Cache updated for key: users:page:1 (TTL: 60s)',
+  ].join('\n'),
+  lorem:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\nSed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit.\n\nAt vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga.',
+};
+
+// --- Algorithm configuration ---
+const ALGOS = {
+  zstd: {
+    label: 'zstd',
+    color: 'blue',
+    levelMin: 1,
+    levelMax: 22,
+    levelDefault: 3,
+    levelHint: '1 = fast, 22 = best ratio',
+    ext: '.zst',
+    compress: (data, level) => zstdCompress(data, level),
+    decompress: (data) => zstdDecompress(data),
+  },
+  gzip: {
+    label: 'gzip',
+    color: 'green',
+    levelMin: 0,
+    levelMax: 9,
+    levelDefault: 6,
+    levelHint: '0 = no compression, 9 = best ratio',
+    ext: '.gz',
+    compress: (data, level) => gzipCompress(data, level),
+    decompress: (data) => gzipDecompress(data),
+  },
+  brotli: {
+    label: 'brotli',
+    color: 'amber',
+    levelMin: 0,
+    levelMax: 11,
+    levelDefault: 6,
+    levelHint: '0 = fast, 11 = best ratio',
+    ext: '.br',
+    compress: (data, level) => brotliCompress(data, level),
+    decompress: (data) => brotliDecompress(data),
+  },
+  lz4: {
+    label: 'lz4',
+    color: 'pink',
+    levelMin: null,
+    levelMax: null,
+    levelDefault: null,
+    levelHint: null,
+    ext: '.lz4',
+    compress: (data) => lz4Compress(data),
+    decompress: (data) => lz4Decompress(data),
+  },
+};
+
+// --- State ---
+let currentAlgo = 'zstd';
+let currentLevel = ALGOS.zstd.levelDefault;
+let currentInput = new Uint8Array(0);
+let currentCompressed = null;
+let currentFileName = 'input';
+let compareTimer = null;
+
+// --- DOM refs ---
+const inputText = document.getElementById('input-text');
+const inputSizeEl = document.getElementById('input-size');
+const algoBtns = document.querySelectorAll('.algo-btn');
+const levelRow = document.getElementById('level-row');
+const levelSlider = document.getElementById('level-slider');
+const levelDisplay = document.getElementById('level-display');
+const levelHint = document.getElementById('level-hint');
+const originalSizeEl = document.getElementById('original-size');
+const compressedSizeEl = document.getElementById('compressed-size');
+const compressionRatioEl = document.getElementById('compression-ratio');
+const compressTimeEl = document.getElementById('compress-time');
+const downloadBtn = document.getElementById('download-btn');
+const compareTable = document.getElementById('compare-table');
+const loadingOverlay = document.getElementById('loading-overlay');
+const sampleBtns = document.querySelectorAll('.sample-btn');
+const fileInput = document.getElementById('file-input');
+
+// --- Utilities ---
+function formatBytes(bytes) {
+  if (bytes === 0) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function formatTime(ms) {
+  if (ms < 1) return `${(ms * 1000).toFixed(0)} µs`;
+  if (ms < 1000) return `${ms.toFixed(1)} ms`;
+  return `${(ms / 1000).toFixed(2)} s`;
+}
+
+function compressData(algo, data, level) {
+  const cfg = ALGOS[algo];
+  const start = performance.now();
+  const compressed = cfg.levelMin !== null ? cfg.compress(data, level) : cfg.compress(data);
+  const elapsed = performance.now() - start;
+  return { compressed, elapsed };
+}
+
+// --- Algorithm selector ---
+function setAlgo(algo) {
+  currentAlgo = algo;
+  const cfg = ALGOS[algo];
+
+  for (const btn of algoBtns) {
+    btn.classList.toggle('active', btn.dataset.algo === algo);
+    btn.setAttribute('data-color', btn.dataset.algo === algo ? ALGOS[btn.dataset.algo].color : '');
+  }
+
+  if (cfg.levelMin !== null) {
+    levelRow.hidden = false;
+    levelSlider.min = cfg.levelMin;
+    levelSlider.max = cfg.levelMax;
+    currentLevel = cfg.levelDefault;
+    levelSlider.value = currentLevel;
+    levelDisplay.textContent = currentLevel;
+    levelHint.textContent = cfg.levelHint;
+  } else {
+    levelRow.hidden = true;
+  }
+
+  compress();
+}
+
+// --- Compress ---
+function compress() {
+  if (currentInput.length === 0) {
+    originalSizeEl.textContent = '—';
+    compressedSizeEl.textContent = '—';
+    compressionRatioEl.textContent = '';
+    compressTimeEl.textContent = '';
+    downloadBtn.hidden = true;
+    currentCompressed = null;
+    return;
+  }
+
+  try {
+    const { compressed, elapsed } = compressData(currentAlgo, currentInput, currentLevel);
+    currentCompressed = compressed;
+
+    const ratio = ((1 - compressed.length / currentInput.length) * 100).toFixed(1);
+
+    originalSizeEl.textContent = formatBytes(currentInput.length);
+    compressedSizeEl.textContent = formatBytes(compressed.length);
+    compressionRatioEl.textContent = `${ratio}% smaller`;
+    compressTimeEl.textContent = formatTime(elapsed);
+    downloadBtn.hidden = false;
+  } catch (err) {
+    compressedSizeEl.textContent = 'Error';
+    compressionRatioEl.textContent = err.message;
+    downloadBtn.hidden = true;
+    currentCompressed = null;
+  }
+
+  scheduleCompare();
+}
+
+// --- Compare (debounced) ---
+function scheduleCompare() {
+  clearTimeout(compareTimer);
+  compareTimer = setTimeout(runCompare, 200);
+}
+
+function runCompare() {
+  if (currentInput.length === 0) {
+    compareTable.innerHTML =
+      '<div class="compare-placeholder">Enter some text above to see comparisons.</div>';
+    return;
+  }
+
+  const results = [];
+
+  for (const [key, cfg] of Object.entries(ALGOS)) {
+    try {
+      const level = cfg.levelDefault;
+      const { compressed, elapsed } = compressData(key, currentInput, level);
+      const ratio = (1 - compressed.length / currentInput.length) * 100;
+      results.push({ key, cfg, compressed, elapsed, ratio });
+    } catch {
+      results.push({ key, cfg, compressed: null, elapsed: 0, ratio: 0, error: true });
+    }
+  }
+
+  const maxRatio = Math.max(...results.map((r) => r.ratio));
+
+  const rows = results
+    .map((r) => {
+      if (r.error) {
+        return `<div class="compare-row">
+          <span class="compare-algo compare-algo--${r.cfg.color}">${r.cfg.label}</span>
+          <span class="compare-error">Error</span>
+        </div>`;
+      }
+
+      const barPct = Math.max(0, Math.min(100, r.ratio));
+      const isSmallest = r.ratio === maxRatio;
+      const levelLabel = r.cfg.levelMin !== null ? ` L${r.cfg.levelDefault}` : '';
+
+      return `<div class="compare-row ${currentAlgo === r.key ? 'compare-row--active' : ''}">
+        <span class="compare-algo compare-algo--${r.cfg.color}">${r.cfg.label}${levelLabel}</span>
+        <div class="compare-bar-wrap">
+          <div class="compare-bar compare-bar--${r.cfg.color}" style="width:${barPct}%"></div>
+        </div>
+        <span class="compare-ratio">${r.ratio.toFixed(1)}%</span>
+        <span class="compare-size">${formatBytes(r.compressed.length)}</span>
+        <span class="compare-time">${formatTime(r.elapsed)}</span>
+        ${isSmallest ? '<span class="compare-badge compare-badge--best">best ratio</span>' : '<span class="compare-badge"></span>'}
+      </div>`;
+    })
+    .join('');
+
+  const fastestIdx = results.reduce(
+    (minIdx, r, idx, arr) => (r.elapsed < arr[minIdx].elapsed ? idx : minIdx),
+    0,
+  );
+
+  compareTable.innerHTML = `
+    <div class="compare-header">
+      <span>Algorithm</span>
+      <span>Ratio (smaller = better)</span>
+      <span>Ratio</span>
+      <span>Size</span>
+      <span>Time</span>
+      <span></span>
+    </div>
+    ${rows}
+    <div class="compare-note">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+      Default levels shown. Adjust level in Compress above to tune ratio vs. speed.
+      Fastest: <strong>${ALGOS[results[fastestIdx].key].label}</strong> at ${formatTime(results[fastestIdx].elapsed)}.
+    </div>`;
+}
+
+// --- Input handling ---
+function onInputChange() {
+  const text = inputText.value;
+  currentInput = new TextEncoder().encode(text);
+  currentFileName = 'input';
+  inputSizeEl.textContent = formatBytes(currentInput.length);
+  compress();
+}
+
+// --- Sample data ---
+for (const btn of sampleBtns) {
+  btn.addEventListener('click', () => {
+    for (const b of sampleBtns) {
+      b.classList.remove('active');
+    }
+    btn.classList.add('active');
+    inputText.value = SAMPLES[btn.dataset.sample];
+    inputText.setSelectionRange(0, 0);
+    inputText.scrollTop = 0;
+    onInputChange();
+  });
+}
+
+// --- File upload ---
+fileInput.addEventListener('change', (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+
+  if (file.size > 10 * 1024 * 1024) {
+    alert('File is larger than 10 MB. Please use a smaller file for the playground.');
+    fileInput.value = '';
+    return;
+  }
+
+  for (const b of sampleBtns) {
+    b.classList.remove('active');
+  }
+  currentFileName = file.name;
+
+  const reader = new FileReader();
+  reader.onload = (ev) => {
+    const bytes = new Uint8Array(ev.target.result);
+    currentInput = bytes;
+
+    if (file.type.startsWith('text/') || file.name.endsWith('.json') || file.name.endsWith('.md')) {
+      inputText.value = new TextDecoder().decode(bytes);
+    } else {
+      inputText.value = `[Binary file: ${file.name} — ${formatBytes(file.size)}]`;
+    }
+
+    inputSizeEl.textContent = formatBytes(currentInput.length);
+    compress();
+  };
+  reader.readAsArrayBuffer(file);
+});
+
+// --- Algorithm buttons ---
+for (const btn of algoBtns) {
+  btn.addEventListener('click', () => setAlgo(btn.dataset.algo));
+}
+
+// --- Level slider ---
+levelSlider.addEventListener('input', () => {
+  currentLevel = Number(levelSlider.value);
+  levelDisplay.textContent = currentLevel;
+  compress();
+});
+
+// --- Download ---
+downloadBtn.addEventListener('click', () => {
+  if (!currentCompressed) return;
+  const blob = new Blob([currentCompressed], { type: 'application/octet-stream' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${currentFileName}${ALGOS[currentAlgo].ext}`;
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+});
+
+// --- Input event ---
+inputText.addEventListener('input', onInputChange);
+
+// --- Init ---
+function init() {
+  // Test that WASM loaded correctly
+  try {
+    const test = new TextEncoder().encode('test');
+    zstdCompress(test);
+  } catch {
+    loadingOverlay.querySelector('.loading-text').textContent =
+      'Failed to load WASM. Please try a modern browser (Chrome, Firefox, Edge, Safari 16.4+).';
+    return;
+  }
+
+  loadingOverlay.classList.add('hidden');
+
+  // Load JSON sample by default
+  inputText.value = SAMPLES.json;
+  onInputChange();
+  setAlgo('zstd');
+
+  // Focus and position cursor at start (prevents auto-scroll to end)
+  inputText.focus();
+  inputText.setSelectionRange(0, 0);
+  inputText.scrollTop = 0;
+}
+
+init();

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "comprs-playground",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "comprs": "file:.."
+  },
+  "devDependencies": {
+    "vite": "^8.0.0"
+  }
+}

--- a/playground/pnpm-lock.yaml
+++ b/playground/pnpm-lock.yaml
@@ -1,0 +1,500 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      comprs:
+        specifier: file:..
+        version: file:..
+    devDependencies:
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.3
+
+packages:
+
+  '@emnapi/core@1.9.1':
+    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+
+  '@emnapi/runtime@1.9.1':
+    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+
+  '@emnapi/wasi-threads@1.2.0':
+    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+
+  '@napi-rs/wasm-runtime@1.1.1':
+    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@oxc-project/types@0.122.0':
+    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+    resolution: {integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+    resolution: {integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.12':
+    resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  comprs@file:..:
+    resolution: {directory: .., type: directory}
+    engines: {node: '>=20.0.0'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rolldown@1.0.0-rc.12:
+    resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  vite@8.0.3:
+    resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+snapshots:
+
+  '@emnapi/core@1.9.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oxc-project/types@0.122.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.12': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  comprs@file:..: {}
+
+  detect-libc@2.1.2: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  nanoid@3.3.11: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rolldown@1.0.0-rc.12:
+    dependencies:
+      '@oxc-project/types': 0.122.0
+      '@rolldown/pluginutils': 1.0.0-rc.12
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
+
+  source-map-js@1.2.1: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tslib@2.8.1:
+    optional: true
+
+  vite@8.0.3:
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.12
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      fsevents: 2.3.3

--- a/playground/public/coi-serviceworker.js
+++ b/playground/public/coi-serviceworker.js
@@ -1,0 +1,116 @@
+/*! coi-serviceworker v0.1.7 - Guido Zuidhof and contributors, licensed under MIT */
+let coepCredentialless = false;
+if (typeof window === 'undefined') {
+  self.addEventListener('install', () => self.skipWaiting());
+  self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));
+
+  self.addEventListener('message', (ev) => {
+    if (!ev.data) {
+      return;
+    } else if (ev.data.type === 'deregister') {
+      self.registration
+        .unregister()
+        .then(() => {
+          return self.clients.matchAll();
+        })
+        .then((clients) => {
+          clients.forEach((client) => client.navigate(client.url));
+        });
+    } else if (ev.data.type === 'coepCredentialless') {
+      coepCredentialless = ev.data.value;
+    }
+  });
+
+  self.addEventListener('fetch', (event) => {
+    const r = event.request;
+    if (r.cache === 'only-if-cached' && r.mode !== 'same-origin') {
+      return;
+    }
+
+    const request =
+      coepCredentialless && r.mode === 'no-cors'
+        ? new Request(r, {
+            credentials: 'omit',
+          })
+        : r;
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          if (response.status === 0) {
+            return response;
+          }
+
+          const newHeaders = new Headers(response.headers);
+          newHeaders.set(
+            'Cross-Origin-Embedder-Policy',
+            coepCredentialless ? 'credentialless' : 'require-corp',
+          );
+          if (!coepCredentialless) {
+            newHeaders.set('Cross-Origin-Resource-Policy', 'cross-origin');
+          }
+          newHeaders.set('Cross-Origin-Opener-Policy', 'same-origin');
+
+          return new Response(response.body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: newHeaders,
+          });
+        })
+        .catch((e) => console.error(e)),
+    );
+  });
+} else {
+  (() => {
+    const coi = {
+      shouldRegister: () => true,
+      shouldDeregister: () => false,
+      coepCredentialless: () => !(window.chrome || window.netscape),
+      doReload: () => window.location.reload(),
+      quiet: false,
+      ...window.coi,
+    };
+
+    const n = navigator;
+
+    if (n.serviceWorker && n.serviceWorker.controller) {
+      n.serviceWorker.controller.postMessage({
+        type: 'coepCredentialless',
+        value: coi.coepCredentialless(),
+      });
+
+      if (coi.shouldDeregister()) {
+        n.serviceWorker.controller.postMessage({ type: 'deregister' });
+      }
+    }
+
+    if (window.crossOriginIsolated !== false || !coi.shouldRegister()) return;
+
+    if (!window.isSecureContext) {
+      !coi.quiet &&
+        console.log('COOP/COEP Service Worker not registered, a secure context is required.');
+      return;
+    }
+
+    if (n.serviceWorker) {
+      n.serviceWorker.register(window.document.currentScript.src).then(
+        (registration) => {
+          !coi.quiet && console.log('COOP/COEP Service Worker registered', registration.scope);
+
+          registration.addEventListener('updatefound', () => {
+            !coi.quiet &&
+              console.log('Reloading page to make use of updated COOP/COEP Service Worker.');
+            coi.doReload();
+          });
+
+          if (registration.active && !n.serviceWorker.controller) {
+            !coi.quiet && console.log('Reloading page to make use of COOP/COEP Service Worker.');
+            coi.doReload();
+          }
+        },
+        (err) => {
+          !coi.quiet && console.error('COOP/COEP Service Worker failed to register:', err);
+        },
+      );
+    }
+  })();
+}

--- a/playground/style.css
+++ b/playground/style.css
@@ -1,0 +1,696 @@
+/* ─── Reset & Base ─────────────────────────────────────────────── */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --bg: #09090b;
+  --surface: #111113;
+  --surface-2: #18181b;
+  --border: #27272a;
+  --border-2: #3f3f46;
+  --text: #fafafa;
+  --muted: #a1a1aa;
+  --muted-2: #71717a;
+
+  /* Algorithm accent colors */
+  --blue: #3b82f6;
+  --green: #22c55e;
+  --amber: #f59e0b;
+  --pink: #ec4899;
+
+  --blue-dim: color-mix(in srgb, var(--blue) 15%, transparent);
+  --green-dim: color-mix(in srgb, var(--green) 15%, transparent);
+  --amber-dim: color-mix(in srgb, var(--amber) 15%, transparent);
+  --pink-dim: color-mix(in srgb, var(--pink) 15%, transparent);
+
+  --radius: 8px;
+  --radius-sm: 5px;
+  --font-sans: "Geist", system-ui, sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, monospace;
+}
+
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+}
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  line-height: 1.5;
+  min-height: 100dvh;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--muted);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+a:hover {
+  color: var(--text);
+}
+
+/* ─── Header ───────────────────────────────────────────────────── */
+header {
+  border-bottom: 1px solid var(--border);
+  padding: 16px 24px 14px;
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.header-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.header-logo {
+  font-size: 1.15rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+
+.badge {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--surface-2);
+  border: 1px solid var(--border-2);
+  color: var(--muted);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.header-nav {
+  display: flex;
+  gap: 20px;
+  font-size: 0.875rem;
+}
+
+.header-subtitle {
+  font-size: 0.8125rem;
+  color: var(--muted-2);
+  text-align: center;
+  margin-top: 8px;
+  max-width: 860px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* ─── Main layout ──────────────────────────────────────────────── */
+main {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 28px 24px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* ─── Cards ────────────────────────────────────────────────────── */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+}
+
+.card-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.card-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -0.01em;
+}
+
+.card-subtitle {
+  font-size: 0.8125rem;
+  color: var(--muted-2);
+}
+
+/* ─── Input card ───────────────────────────────────────────────── */
+.sample-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.sample-label {
+  font-size: 0.75rem;
+  color: var(--muted-2);
+  margin-right: 2px;
+}
+
+.sample-btn {
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 3px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-2);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: all 0.12s;
+}
+
+.sample-btn:hover {
+  background: var(--surface-2);
+  color: var(--text);
+  border-color: var(--border-2);
+}
+
+.sample-btn.active {
+  background: var(--surface-2);
+  color: var(--text);
+  border-color: var(--border-2);
+}
+
+.upload-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 3px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px dashed var(--border-2);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: all 0.12s;
+}
+
+.upload-btn:hover {
+  background: var(--surface-2);
+  color: var(--text);
+  border-color: var(--border-2);
+  border-style: solid;
+}
+
+.upload-btn input[type="file"] {
+  display: none;
+}
+
+#input-text {
+  width: 100%;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  padding: 12px 14px;
+  resize: vertical;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+#input-text:focus {
+  border-color: var(--border-2);
+}
+#input-text::placeholder {
+  color: var(--muted-2);
+}
+
+.input-footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 6px;
+}
+
+.input-size {
+  font-size: 0.75rem;
+  color: var(--muted-2);
+  font-family: var(--font-mono);
+}
+
+/* ─── Compress card ────────────────────────────────────────────── */
+.algo-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.algo-btn {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  font-family: var(--font-mono);
+  padding: 6px 16px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-2);
+  background: var(--surface-2);
+  color: var(--muted);
+  cursor: pointer;
+  transition: all 0.15s;
+  letter-spacing: -0.01em;
+}
+
+.algo-btn:hover {
+  color: var(--text);
+  border-color: var(--border-2);
+}
+
+.algo-btn.active[data-algo="zstd"] {
+  background: var(--blue-dim);
+  color: var(--blue);
+  border-color: var(--blue);
+}
+.algo-btn.active[data-algo="gzip"] {
+  background: var(--green-dim);
+  color: var(--green);
+  border-color: var(--green);
+}
+.algo-btn.active[data-algo="brotli"] {
+  background: var(--amber-dim);
+  color: var(--amber);
+  border-color: var(--amber);
+}
+.algo-btn.active[data-algo="lz4"] {
+  background: var(--pink-dim);
+  color: var(--pink);
+  border-color: var(--pink);
+}
+
+/* Level control */
+.level-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+  padding: 12px 14px;
+  background: var(--surface-2);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+}
+
+.level-label {
+  font-size: 0.8125rem;
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+}
+
+.level-value {
+  font-family: var(--font-mono);
+  color: var(--text);
+  font-weight: 500;
+  min-width: 1.5ch;
+  text-align: right;
+}
+
+.slider {
+  appearance: none;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--border-2);
+  outline: none;
+  cursor: pointer;
+}
+
+.slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--text);
+  cursor: pointer;
+  transition: transform 0.1s;
+}
+
+.slider::-webkit-slider-thumb:hover {
+  transform: scale(1.2);
+}
+.slider::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--text);
+  border: none;
+  cursor: pointer;
+}
+
+.level-hint {
+  font-size: 0.6875rem;
+  color: var(--muted-2);
+  white-space: nowrap;
+}
+
+/* Result grid */
+.result-grid {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.result-box {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 14px 16px;
+  text-align: center;
+}
+
+.result-box--accent {
+  border-color: var(--border-2);
+}
+
+.result-label {
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-2);
+  margin-bottom: 4px;
+}
+
+.result-value {
+  font-family: var(--font-mono);
+  font-size: 1.25rem;
+  font-weight: 500;
+  color: var(--text);
+  letter-spacing: -0.03em;
+}
+
+.result-ratio {
+  font-size: 0.75rem;
+  color: var(--green);
+  margin-top: 3px;
+  font-family: var(--font-mono);
+}
+
+.result-arrow {
+  color: var(--muted-2);
+  display: flex;
+  align-items: center;
+}
+
+.result-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding-left: 4px;
+}
+
+.result-time {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--muted-2);
+}
+
+.download-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 5px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-2);
+  background: var(--surface-2);
+  color: var(--muted);
+  cursor: pointer;
+  transition: all 0.12s;
+  white-space: nowrap;
+}
+
+.download-btn:hover {
+  color: var(--text);
+  background: var(--surface);
+}
+
+/* ─── Compare card ─────────────────────────────────────────────── */
+.compare-placeholder {
+  color: var(--muted-2);
+  font-size: 0.875rem;
+  text-align: center;
+  padding: 20px 0;
+}
+
+.compare-header {
+  display: grid;
+  grid-template-columns: 120px 1fr 52px 58px 54px 72px;
+  gap: 8px;
+  align-items: center;
+  padding: 0 0 8px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 2px;
+  font-size: 0.6875rem;
+  color: var(--muted-2);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.compare-row {
+  display: grid;
+  grid-template-columns: 120px 1fr 52px 58px 54px 72px;
+  gap: 8px;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+  transition: background 0.1s;
+}
+
+.compare-row:last-of-type {
+  border-bottom: none;
+}
+
+.compare-row--active {
+  background: color-mix(in srgb, var(--text) 2%, transparent);
+  margin: 0 -8px;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: var(--radius-sm);
+}
+
+.compare-algo {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  font-weight: 500;
+}
+
+.compare-algo--blue {
+  color: var(--blue);
+}
+.compare-algo--green {
+  color: var(--green);
+}
+.compare-algo--amber {
+  color: var(--amber);
+}
+.compare-algo--pink {
+  color: var(--pink);
+}
+
+.compare-bar-wrap {
+  height: 6px;
+  background: var(--surface-2);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.compare-bar {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.compare-bar--blue {
+  background: var(--blue);
+}
+.compare-bar--green {
+  background: var(--green);
+}
+.compare-bar--amber {
+  background: var(--amber);
+}
+.compare-bar--pink {
+  background: var(--pink);
+}
+
+.compare-ratio,
+.compare-size,
+.compare-time {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--muted);
+  text-align: right;
+}
+
+.compare-ratio {
+  color: var(--text);
+}
+
+.compare-badge {
+  font-size: 0.6875rem;
+  padding: 2px 7px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.compare-badge--best {
+  background: color-mix(in srgb, var(--green) 15%, transparent);
+  color: var(--green);
+  border: 1px solid color-mix(in srgb, var(--green) 30%, transparent);
+}
+
+.compare-error {
+  color: #ef4444;
+  font-size: 0.8125rem;
+  grid-column: 2 / -1;
+}
+
+.compare-note {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 14px;
+  font-size: 0.75rem;
+  color: var(--muted-2);
+  flex-wrap: wrap;
+}
+
+.compare-note strong {
+  color: var(--muted);
+}
+
+/* ─── Footer ───────────────────────────────────────────────────── */
+footer {
+  border-top: 1px solid var(--border);
+  padding: 20px 24px;
+}
+
+.footer-inner {
+  max-width: 860px;
+  margin: 0 auto;
+  text-align: center;
+  font-size: 0.8125rem;
+  color: var(--muted-2);
+}
+
+.footer-inner a {
+  color: var(--muted);
+}
+
+.footer-inner a:hover {
+  color: var(--text);
+}
+
+/* ─── Loading overlay ──────────────────────────────────────────── */
+.loading-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  transition: opacity 0.3s;
+}
+
+.loading-overlay.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.loading-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.spinner {
+  width: 28px;
+  height: 28px;
+  border: 2px solid var(--border-2);
+  border-top-color: var(--text);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.loading-text {
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+
+/* ─── Utility ──────────────────────────────────────────────────── */
+[hidden] {
+  display: none;
+}
+
+/* ─── Responsive ───────────────────────────────────────────────── */
+@media (max-width: 600px) {
+  main {
+    padding: 16px 14px 36px;
+  }
+  header {
+    padding: 12px 14px 10px;
+  }
+
+  .result-grid {
+    grid-template-columns: 1fr auto 1fr;
+    grid-template-rows: auto auto;
+  }
+
+  .result-meta {
+    grid-column: 1 / -1;
+    flex-direction: row;
+    align-items: center;
+    padding-left: 0;
+    padding-top: 4px;
+  }
+
+  .compare-header,
+  .compare-row {
+    grid-template-columns: 90px 1fr 48px 0 54px 0;
+  }
+
+  .compare-header span:nth-child(4),
+  .compare-header span:nth-child(6),
+  .compare-row .compare-size,
+  .compare-row .compare-badge {
+    display: none;
+  }
+
+  .level-hint {
+    display: none;
+  }
+  .level-row {
+    grid-template-columns: auto 1fr;
+  }
+}

--- a/playground/vite.config.js
+++ b/playground/vite.config.js
@@ -1,0 +1,42 @@
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+
+// Use local WASM build when available (after `pnpm run build:wasm` in repo root).
+// On GitHub Pages CI, WASM is built before this runs. In development without a
+// local WASM build, falls back to a JS mock so the UI can be previewed.
+const localWasmEntry = fileURLToPath(new URL('../comprs.wasi-browser.js', import.meta.url));
+const hasLocalWasm = existsSync(localWasmEntry);
+const mockEntry = fileURLToPath(new URL('./comprs-mock.js', import.meta.url));
+const browserEntry = fileURLToPath(new URL('../browser-entry.js', import.meta.url));
+
+const corsHeaders = {
+  'Cross-Origin-Opener-Policy': 'same-origin',
+  'Cross-Origin-Embedder-Policy': 'require-corp',
+};
+
+export default defineConfig({
+  base: process.env.GITHUB_ACTIONS ? '/comprs/' : '/',
+  build: {
+    // WASM entry uses top-level await (requires es2022+)
+    target: 'es2022',
+  },
+  server: {
+    headers: corsHeaders,
+  },
+  preview: {
+    headers: corsHeaders,
+  },
+  resolve: {
+    alias: hasLocalWasm
+      ? {
+          // Real WASM: point comprs to browser entry + use local WASM build
+          comprs: browserEntry,
+          'comprs-wasm32-wasi': localWasmEntry,
+        }
+      : {
+          // Dev mock: bypass WASM entirely with a JS fallback
+          comprs: mockEntry,
+        },
+  },
+});


### PR DESCRIPTION
## Summary

- Add a browser-based compression playground at `playground/` with support for zstd, gzip, brotli, and lz4
- Include level slider, algorithm comparison table, sample data (JSON/Log/Text), file upload, and compressed file download
- Deploy automatically to GitHub Pages via new `.github/workflows/playground.yml` CI workflow
- Use a JS mock (`comprs-mock.js`) for local dev when no WASM build is available; Vite aliases switch to real WASM when built
- Update `biome.json` with overrides for playground-specific files (vite config, COI service worker)
- Add playground badge and live link to `README.md`

## Related issue

Closes #258

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (18 passed, 1 skipped)
- [x] `cargo test` passes (59 passed)
- [x] `cargo clippy` passes