### PR TITLE
docs: improve playground visibility and add OGP/SEO meta tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Rust-powered universal compression for JavaScript/TypeScript.
 [![TypeScript](https://img.shields.io/badge/TypeScript-ready-blue)](https://www.typescriptlang.org/)
 [![Playground](https://img.shields.io/badge/playground-try%20it%20live-8b5cf6)](https://derodero24.github.io/comprs/)
 
+**[→ Try the live playground](https://derodero24.github.io/comprs/)**
+
 </div>
 
 ## Table of Contents
@@ -41,6 +43,7 @@ The JavaScript compression ecosystem is fragmented across 12+ packages with inco
 - **Streaming** — Web Streams API (`TransformStream`) for processing large data with bounded memory
 - **Universal** — Node.js (native), browsers, Deno, and Bun (WASM)
 - **Zero JS dependencies** — Only Rust and the platform
+- **Interactive playground** — [Try any algorithm live in your browser](https://derodero24.github.io/comprs/), no install needed
 
 ## Comparison with Alternatives
 

--- a/playground/index.html
+++ b/playground/index.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>comprs Playground</title>
   <meta name="description" content="Interactive playground for comprs — Rust-powered zstd, gzip, brotli, and lz4 compression for JavaScript.">
+  <link rel="canonical" href="https://derodero24.github.io/comprs/">
+  <meta property="og:title" content="comprs Playground">
+  <meta property="og:description" content="Try Rust-powered zstd, gzip, brotli, and lz4 compression live in your browser. No install needed.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://derodero24.github.io/comprs/">
+  <meta property="og:site_name" content="comprs">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="comprs Playground">
+  <meta name="twitter:description" content="Try Rust-powered zstd, gzip, brotli, and lz4 compression live in your browser. No install needed.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500&family=Geist:wght@400;500;600&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary

- Add prominent **"→ Try the live playground"** text link below the badge row in the README header
- Add playground as a feature bullet in the "Why comprs?" section
- Add Open Graph meta tags to `playground/index.html` for rich link previews
- Add Twitter Card meta tags
- Add `<link rel="canonical">` for SEO deduplication

## Related issue

Closes #260

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes
- [x] `cargo test` passes