### PR TITLE
fix(playground): handle COI not established on first visit

### DIFF
--- a/playground/main.js
+++ b/playground/main.js
@@ -362,13 +362,35 @@ inputText.addEventListener('input', onInputChange);
 
 // --- Init ---
 function init() {
+  const loadingText = loadingOverlay.querySelector('.loading-text');
+
+  // WASM uses SharedArrayBuffer (threading), which requires Cross-Origin Isolation.
+  // The COI service worker auto-reloads the page to establish isolation on first visit.
+  // If the reload hasn't happened yet, wait rather than failing immediately.
+  if (!crossOriginIsolated) {
+    loadingText.textContent = 'Enabling security features\u2026 the page will reload shortly.';
+    setTimeout(() => {
+      if (!crossOriginIsolated) {
+        loadingText.textContent =
+          'Could not establish Cross-Origin Isolation. Please reload the page.';
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.textContent = 'Reload';
+        btn.className = 'loading-reload-btn';
+        btn.addEventListener('click', () => location.reload());
+        loadingText.after(btn);
+      }
+    }, 3000);
+    return;
+  }
+
   // Test that WASM loaded correctly
   try {
     const test = new TextEncoder().encode('test');
     zstdCompress(test);
-  } catch {
-    loadingOverlay.querySelector('.loading-text').textContent =
-      'Failed to load WASM. Please try a modern browser (Chrome, Firefox, Edge, Safari 16.4+).';
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    loadingText.textContent = `Failed to initialize WASM (${msg}). Try reloading, or use Chrome, Firefox, Edge, or Safari 16.4+.`;
     return;
   }
 

--- a/playground/style.css
+++ b/playground/style.css
@@ -646,6 +646,24 @@ footer {
 .loading-text {
   font-size: 0.875rem;
   color: var(--muted);
+  text-align: center;
+  max-width: 320px;
+}
+
+.loading-reload-btn {
+  margin-top: 4px;
+  padding: 7px 22px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.loading-reload-btn:hover {
+  opacity: 0.85;
 }
 
 /* ─── Utility ──────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

On first visit to the playground, the COI service worker has not yet reloaded the page, so `crossOriginIsolated` is `false`. Calling the WASM-backed `zstdCompress()` immediately throws because `SharedArrayBuffer` is unavailable. This showed a misleading "unsupported browser" error in modern browsers like Vivaldi, Brave, and Arc.

Changes:
- Check `crossOriginIsolated` **before** invoking WASM in `init()`
- Show _"Enabling security features… the page will reload shortly."_ while the COI service worker handles the auto-reload
- After 3 seconds (if auto-reload didn't happen), show a manual **Reload** button
- Include the actual `err.message` when WASM init genuinely fails (instead of swallowing it)
- Add `.loading-reload-btn` styles to `style.css`

## Related issue

Closes #262

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes
- [x] `cargo test` passes