### PR TITLE
fix(playground): add Buffer polyfill for emnapi WASM compatibility

### DIFF
--- a/playground/main.js
+++ b/playground/main.js
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import {
   brotliCompress,
   brotliDecompress,
@@ -8,6 +9,12 @@ import {
   zstdCompress,
   zstdDecompress,
 } from 'comprs';
+
+// emnapi (napi-rs WASM runtime) requires globalThis.Buffer.
+// Browsers do not define it natively, so polyfill before any WASM call.
+if (!globalThis.Buffer) {
+  globalThis.Buffer = Buffer;
+}
 
 // --- Sample data ---
 const SAMPLES = {

--- a/playground/package.json
+++ b/playground/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "buffer": "^6.0.3",
     "comprs": "file:.."
   },
   "devDependencies": {

--- a/playground/pnpm-lock.yaml
+++ b/playground/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      buffer:
+        specifier: ^6.0.3
+        version: 6.0.3
       comprs:
         specifier: file:..
         version: file:..
@@ -134,6 +137,12 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
   comprs@file:..:
     resolution: {directory: .., type: directory}
     engines: {node: '>=20.0.0'}
@@ -155,6 +164,9 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -386,6 +398,13 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  base64-js@1.5.1: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   comprs@file:..: {}
 
   detect-libc@2.1.2: {}
@@ -396,6 +415,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  ieee754@1.2.1: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true


### PR DESCRIPTION
## Summary

- Import `Buffer` from the `buffer` npm package and assign it to `globalThis.Buffer` before any WASM function calls
- Add `buffer@^6.0.3` to playground dependencies and update `pnpm-lock.yaml`
- Fixes the error reported in Vivaldi (Chromium 146): `emnapi_create_memory_view: The current runtime does not support 'Buffer'. Consider using buffer polyfill to make sure globalThis.Buffer is defined.`

The root cause: emnapi (the JS runtime that bridges napi-rs WASM to browser) requires `globalThis.Buffer` when creating memory views for function arguments. Browsers do not define `Buffer` natively, so it must be polyfilled.

The fix sets `globalThis.Buffer` at module evaluation time — after WASM module initialization (which uses top-level await) but before any WASM function is invoked in `init()`.

## Related issue

Closes #264

## Checklist

- [x] `pnpm run check` passes (Biome lint)
- [x] `pnpm test` passes (440 tests)
- [x] `pnpm build` (Vite) succeeds — bundle includes `globalThis.Buffer` assignment
- [x] Change is minimal (7 lines: import + conditional assignment + lock file update)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * プレイグラウンド環境のブラウザ互換性を改善しました。

---

**変更行数**: +8/-0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->