### PR TITLE
fix(playground): use dynamic import for comprs to ensure Buffer is set before WASM init

### DIFF
--- a/playground/main.js
+++ b/playground/main.js
@@ -1,5 +1,16 @@
 import { Buffer } from 'buffer';
-import {
+
+// emnapi (napi-rs WASM runtime) requires globalThis.Buffer when creating
+// memory views for WASM function arguments. Browsers do not define it natively.
+// Must be set BEFORE the comprs WASM module initializes (top-level await in
+// comprs-wasm32-wasi runs __emnapiInstantiateNapiModuleSync at import time).
+// Static imports are hoisted and evaluated before any module body code, so
+// a dynamic import is used to ensure Buffer is set first.
+if (!globalThis.Buffer) {
+  globalThis.Buffer = Buffer;
+}
+
+const {
   brotliCompress,
   brotliDecompress,
   gzipCompress,
@@ -8,13 +19,7 @@ import {
   lz4Decompress,
   zstdCompress,
   zstdDecompress,
-} from 'comprs';
-
-// emnapi (napi-rs WASM runtime) requires globalThis.Buffer.
-// Browsers do not define it natively, so polyfill before any WASM call.
-if (!globalThis.Buffer) {
-  globalThis.Buffer = Buffer;
-}
+} = await import('comprs');
 
 // --- Sample data ---
 const SAMPLES = {

--- a/playground/vite.config.js
+++ b/playground/vite.config.js
@@ -23,6 +23,9 @@ export default defineConfig({
   },
   server: {
     headers: corsHeaders,
+    // Allow serving WASM files from parent directory during local development
+    // (comprs.wasm32-wasi.wasm lives in repo root, outside the playground dir)
+    fs: hasLocalWasm ? { allow: ['..'] } : {},
   },
   preview: {
     headers: corsHeaders,


### PR DESCRIPTION
## Summary

- Change `comprs` import from static to dynamic (`await import('comprs')`) so the Buffer polyfill is set before WASM module initialization

## Root cause

PR #265 attempted to fix the `emnapi_create_memory_view: Buffer not defined` error by adding `import { Buffer } from 'buffer'` and setting `globalThis.Buffer = Buffer` in the module body. This did not work due to ES module evaluation order:

1. All static imports are hoisted and evaluated **before** any module body code runs
2. `buffer` package evaluates → `Buffer` class created, but **not** yet on `globalThis`
3. `comprs-wasm32-wasi` evaluates → `__emnapiInstantiateNapiModuleSync` calls emnapi_create_memory_view → needs `globalThis.Buffer` → **not found → error**
4. `main.js` body runs: `globalThis.Buffer = Buffer` → **too late**

`bufferDefined: true` was observed after page load because the module body eventually ran, but the error had already occurred during step 3.

## Fix

Use a dynamic `await import('comprs')` so the comprs WASM module initializes **after** `globalThis.Buffer` is set:

```js
import { Buffer } from 'buffer';

if (!globalThis.Buffer) {
  globalThis.Buffer = Buffer;  // ← executed before dynamic import
}

const { zstdCompress, ... } = await import('comprs');  // ← WASM init happens here, Buffer already set
```

## Related issue

Closes #266, follows up on #264 / #265

## Checklist

- [x] `pnpm run check` passes (Biome lint)
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (440 tests)
- [x] `pnpm build` (Vite) succeeds
- [x] pre-push hooks all pass (check + typecheck + test + clippy + cargo-test + cargo-deny)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 圧縮モジュールの読み込み順序を見直し、バッファ初期化が確実に行われるようにして起動の安定性を向上しました。
* **Chores**
  * ローカルのWASMビルドが存在する場合、開発サーバーが親ディレクトリからそのビルドを読み取れるように条件付きで許可を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->