### PR TITLE
fix(playground): fix negative ratio text, CSS variable, download label, and file size alert

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -57,6 +57,7 @@
       </div>
       <textarea id="input-text" rows="8" spellcheck="false" placeholder="Enter text to compress…"></textarea>
       <div class="input-footer">
+        <span class="file-error" id="file-error" hidden></span>
         <span class="input-size" id="input-size">0 B</span>
       </div>
     </div>
@@ -100,7 +101,7 @@
           <div class="result-time" id="compress-time"></div>
           <button type="button" class="download-btn" id="download-btn" hidden>
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-            Download
+            Download<span id="download-ext"></span>
           </button>
         </div>
       </div>

--- a/playground/main.js
+++ b/playground/main.js
@@ -128,10 +128,12 @@ const compressedSizeEl = document.getElementById('compressed-size');
 const compressionRatioEl = document.getElementById('compression-ratio');
 const compressTimeEl = document.getElementById('compress-time');
 const downloadBtn = document.getElementById('download-btn');
+const downloadExtEl = document.getElementById('download-ext');
 const compareTable = document.getElementById('compare-table');
 const loadingOverlay = document.getElementById('loading-overlay');
 const sampleBtns = document.querySelectorAll('.sample-btn');
 const fileInput = document.getElementById('file-input');
+const fileError = document.getElementById('file-error');
 
 // --- Utilities ---
 function formatBytes(bytes) {
@@ -177,6 +179,8 @@ function setAlgo(algo) {
     levelRow.hidden = true;
   }
 
+  downloadExtEl.textContent = cfg.ext;
+
   compress();
 }
 
@@ -196,11 +200,17 @@ function compress() {
     const { compressed, elapsed } = compressData(currentAlgo, currentInput, currentLevel);
     currentCompressed = compressed;
 
-    const ratio = ((1 - compressed.length / currentInput.length) * 100).toFixed(1);
+    const ratio = (1 - compressed.length / currentInput.length) * 100;
 
     originalSizeEl.textContent = formatBytes(currentInput.length);
     compressedSizeEl.textContent = formatBytes(compressed.length);
-    compressionRatioEl.textContent = `${ratio}% smaller`;
+    if (ratio >= 0) {
+      compressionRatioEl.textContent = `${ratio.toFixed(1)}% smaller`;
+      compressionRatioEl.classList.remove('is-expanded');
+    } else {
+      compressionRatioEl.textContent = `${(-ratio).toFixed(1)}% larger`;
+      compressionRatioEl.classList.add('is-expanded');
+    }
     compressTimeEl.textContent = formatTime(elapsed);
     downloadBtn.hidden = false;
   } catch (err) {
@@ -327,7 +337,11 @@ fileInput.addEventListener('change', (e) => {
   if (!file) return;
 
   if (file.size > 10 * 1024 * 1024) {
-    alert('File is larger than 10 MB. Please use a smaller file for the playground.');
+    fileError.textContent = 'File exceeds the 10 MB limit. Please use a smaller file.';
+    fileError.hidden = false;
+    setTimeout(() => {
+      fileError.hidden = true;
+    }, 5000);
     fileInput.value = '';
     return;
   }

--- a/playground/style.css
+++ b/playground/style.css
@@ -248,6 +248,12 @@ main {
   font-family: var(--font-mono);
 }
 
+.file-error {
+  font-size: 0.75rem;
+  color: #ef4444;
+  font-family: var(--font-mono);
+}
+
 /* ─── Compress card ────────────────────────────────────────────── */
 .algo-row {
   display: flex;
@@ -404,6 +410,10 @@ main {
   color: var(--green);
   margin-top: 3px;
   font-family: var(--font-mono);
+}
+
+.result-ratio.is-expanded {
+  color: var(--muted-2);
 }
 
 .result-arrow {
@@ -659,8 +669,8 @@ footer {
 .loading-reload-btn {
   margin-top: 4px;
   padding: 7px 22px;
-  background: var(--accent);
-  color: #fff;
+  background: var(--text);
+  color: var(--bg);
   border: none;
   border-radius: 6px;
   font-size: 0.875rem;


### PR DESCRIPTION
## Summary

- Show `X% larger` instead of `-X% smaller` when compressed output exceeds input size
- Fix reload button using undefined `var(--accent)`; replace with `var(--text)` / `var(--bg)`
- Add file extension to download button (e.g. `Download .zst`) via `#download-ext` span updated on algo change
- Replace `alert()` for oversized file uploads with inline error message that auto-dismisses after 5 seconds

## Related issue

Closes #272

## Checklist

- [x] All four bugs/UX issues fixed
- [x] Verified locally in Chrome — negative ratio displays correctly, download label updates on algo switch
- [x] Biome lint passes
- [x] TypeScript typecheck passes
- [x] All tests pass