### PR TITLE
fix(playground): add FileReader error handler and textarea aria-label

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -55,7 +55,7 @@
           </label>
         </div>
       </div>
-      <textarea id="input-text" rows="8" spellcheck="false" placeholder="Enter text to compress…"></textarea>
+      <textarea id="input-text" rows="8" spellcheck="false" placeholder="Enter text to compress…" aria-label="Enter text to compress"></textarea>
       <div class="input-footer">
         <span class="file-error" id="file-error" hidden></span>
         <span class="input-size" id="input-size">0 B</span>

--- a/playground/main.js
+++ b/playground/main.js
@@ -352,6 +352,14 @@ fileInput.addEventListener('change', (e) => {
   currentFileName = file.name;
 
   const reader = new FileReader();
+  reader.onerror = () => {
+    fileError.textContent = 'Failed to read the file. Please try again.';
+    fileError.hidden = false;
+    setTimeout(() => {
+      fileError.hidden = true;
+    }, 5000);
+    fileInput.value = '';
+  };
   reader.onload = (ev) => {
     const bytes = new Uint8Array(ev.target.result);
     currentInput = bytes;


### PR DESCRIPTION
## Summary

- Add `reader.onerror` handler in the file upload flow: when `FileReader.readAsArrayBuffer` fails (disk error, revoked access, etc.), show the existing inline error element instead of silently doing nothing
- Add `aria-label="Enter text to compress"` to the input textarea for screen reader accessibility

## Related issue

Closes #274

## Checklist

- [x] Biome lint passes
- [x] TypeScript typecheck passes
- [x] All tests pass