### PR TITLE
fix(config): update biome.json schema to v2.4.10

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## Summary

- Update `biome.json` `$schema` from `2.4.8` to `2.4.10` to match the installed Biome CLI version (updated in #279)
- Ran `biome migrate --write` to apply the schema migration

Closes #288

## Checklist

- [x] `pnpm run check` passes without schema version mismatch warning
- [x] All pre-push hooks pass (lint, typecheck, test, clippy, cargo test, cargo-deny)