### PR TITLE
fix(core): remove unused wildcard import in crc test module

### DIFF
--- a/crates/core/src/crc.rs
+++ b/crates/core/src/crc.rs
@@ -21,8 +21,6 @@ pub fn crc32(data: Either<Buffer, Uint8Array>, initial_value: Option<u32>) -> u3
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     fn compute(data: &[u8], init: Option<u32>) -> u32 {
         let mut hasher = match init {
             Some(v) => crc32fast::Hasher::new_with_initial(v),


### PR DESCRIPTION
## Summary
- Remove unused `use super::*;` import in `crates/core/src/crc.rs` test module
- The test module's `compute` helper uses `crc32fast` directly and does not reference any items from the parent module, so the wildcard import was unnecessary

Closes #289

## Checklist
- [x] `cargo test` passes with no unused import warnings
- [x] `cargo clippy` passes
- [x] All pre-push hooks pass (clippy, cargo-test, lint, cargo-deny, typecheck, vitest)