### PR TITLE
fix(ci): resolve Renovate lookup failures for setup-deno and changesets/action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,7 +367,7 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-      - uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: v2.x
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Create version PR or detect release
         id: changesets
-        uses: changesets/action@ce079ea084e08a340947ed4d6ecedb2433c8f293 # v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           version: pnpm run changeset:version
           title: "chore(release): version packages"


### PR DESCRIPTION
## Summary
- Update `denoland/setup-deno` from pinned `v2` to `v2.0.4` with correct digest
- Update `changesets/action` from pinned `v1` to `v1.7.0` with correct digest

## Problem
Renovate reported lookup failures because these actions don't have floating major version tags (`v2`, `v1`). They only publish specific version tags (e.g., `v2.0.4`, `v1.7.0`), which prevented Renovate from resolving digests when `pinDigests: true` is configured.

## Solution
Pin to specific version tags in the comments so Renovate can resolve the digest and track future updates.

Closes #290