### PR TITLE
refactor: rename npm package to @derodero24/comprs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
 
           # Skip if already published
-          if npm view "comprs@${VERSION}" version 2>/dev/null; then
+          if npm view "@derodero24/comprs@${VERSION}" version 2>/dev/null; then
             echo "Version ${VERSION} already published, skipping release PR"
             exit 0
           fi
@@ -96,7 +96,7 @@ jobs:
         id: check
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          if npm view "comprs@${VERSION}" version 2>/dev/null; then
+          if npm view "@derodero24/comprs@${VERSION}" version 2>/dev/null; then
             echo "Version ${VERSION} already published, skipping"
             echo "should_publish=false" >> $GITHUB_OUTPUT
           else

--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ The JavaScript compression ecosystem is fragmented across 12+ packages with inco
 ## Installation
 
 ```bash
-npm install comprs
+npm install @derodero24/comprs
 # or
-pnpm add comprs
+pnpm add @derodero24/comprs
 # or
-yarn add comprs
+yarn add @derodero24/comprs
 # or
-bun add comprs
+bun add @derodero24/comprs
 ```
 
 ## Quick Start
@@ -83,7 +83,7 @@ bun add comprs
 > **Try it live** → [derodero24.github.io/comprs](https://derodero24.github.io/comprs/)
 
 ```typescript
-import { zstdCompress, zstdDecompress } from 'comprs';
+import { zstdCompress, zstdDecompress } from '@derodero24/comprs';
 
 const data = Buffer.from('Hello, comprs!');
 const compressed = zstdCompress(data);
@@ -93,7 +93,7 @@ const decompressed = zstdDecompress(compressed);
 All algorithms use the same pattern:
 
 ```typescript
-import { gzipCompress, brotliCompress, lz4Compress } from 'comprs';
+import { gzipCompress, brotliCompress, lz4Compress } from '@derodero24/comprs';
 
 const gzipped = gzipCompress(data);    // gzip
 const brotlied = brotliCompress(data); // brotli
@@ -103,7 +103,7 @@ const lz4ed = lz4Compress(data);       // lz4
 ### Streaming (Web Streams API)
 
 ```typescript
-import { createGzipCompressStream, createGzipDecompressStream } from 'comprs/streams';
+import { createGzipCompressStream, createGzipDecompressStream } from '@derodero24/comprs/streams';
 
 // Pipe through compression/decompression TransformStreams
 const compressed = response.body
@@ -113,7 +113,7 @@ const compressed = response.body
 ### Streaming (Node.js Transform)
 
 ```typescript
-import { createGzipCompressTransform } from 'comprs/node';
+import { createGzipCompressTransform } from '@derodero24/comprs/node';
 import { pipeline } from 'node:stream/promises';
 import { createReadStream, createWriteStream } from 'node:fs';
 
@@ -127,7 +127,7 @@ await pipeline(
 ### Auto-detect
 
 ```typescript
-import { decompress } from 'comprs';
+import { decompress } from '@derodero24/comprs';
 
 // Works with any supported format — no need to know the algorithm
 const decompressed = decompress(compressedData);
@@ -136,7 +136,7 @@ const decompressed = decompress(compressedData);
 ### Async
 
 ```typescript
-import { gzipCompressAsync, gzipDecompressAsync } from 'comprs';
+import { gzipCompressAsync, gzipDecompressAsync } from '@derodero24/comprs';
 
 // Runs on the libuv thread pool — keeps the event loop free
 const compressed = await gzipCompressAsync(largeData);
@@ -146,7 +146,7 @@ const decompressed = await gzipDecompressAsync(compressed);
 ### Compression levels
 
 ```typescript
-import { zstdCompress } from 'comprs';
+import { zstdCompress } from '@derodero24/comprs';
 
 zstdCompress(data, 1);   // fast compression
 zstdCompress(data);      // default (level 3)
@@ -157,7 +157,7 @@ zstdCompress(data, -1);  // fast mode with negative levels
 ### Dictionary compression
 
 ```typescript
-import { zstdTrainDictionary, zstdCompressWithDict, zstdDecompressWithDict } from 'comprs';
+import { zstdTrainDictionary, zstdCompressWithDict, zstdDecompressWithDict } from '@derodero24/comprs';
 
 // Train from samples of similar data
 const dict = zstdTrainDictionary(samples);
@@ -169,7 +169,7 @@ const decompressed = zstdDecompressWithDict(compressed, dict);
 
 ```typescript
 // Brotli dictionary (no training step — provide raw dictionary bytes)
-import { brotliCompressWithDict, brotliDecompressWithDict } from 'comprs';
+import { brotliCompressWithDict, brotliDecompressWithDict } from '@derodero24/comprs';
 
 const dict = Buffer.from('{"id":0,"name":"","email":"@example.com"}'.repeat(10));
 const compressed = brotliCompressWithDict(data, dict);
@@ -183,7 +183,7 @@ const decompressed = brotliDecompressWithDict(compressed, dict);
 import { gzipCompress } from 'npm:comprs';
 
 // Bun (same as Node.js)
-import { gzipCompress } from 'comprs';
+import { gzipCompress } from '@derodero24/comprs';
 ```
 
 ## Choosing an Algorithm
@@ -326,7 +326,7 @@ const decompressed = await gzipDecompressAsync(compressed);
 Web Streams API (`TransformStream`) for all algorithms. Import from `comprs/streams`:
 
 ```typescript
-import { createGzipCompressStream } from 'comprs/streams';
+import { createGzipCompressStream } from '@derodero24/comprs/streams';
 ```
 
 <details>
@@ -357,7 +357,7 @@ import { createGzipCompressStream } from 'comprs/streams';
 For Node.js `stream.pipeline()` compatibility, import from `comprs/node`:
 
 ```typescript
-import { createGzipCompressTransform } from 'comprs/node';
+import { createGzipCompressTransform } from '@derodero24/comprs/node';
 import { pipeline } from 'node:stream/promises';
 import { createReadStream, createWriteStream } from 'node:fs';
 
@@ -427,7 +427,7 @@ The WASM binary (`wasm32-wasip1-threads`) is optimized with `wasm-opt -O3` durin
 comprs works in browsers via WASM. Use a bundler like Vite, webpack, or esbuild:
 
 ```typescript
-import { gzipCompress, gzipDecompress } from 'comprs';
+import { gzipCompress, gzipDecompress } from '@derodero24/comprs';
 
 const data = new TextEncoder().encode('Hello from the browser!');
 const compressed = gzipCompress(data);
@@ -481,7 +481,7 @@ On the client side, comprs automatically falls back to WASM — no additional co
 - import pako from 'pako';
 - const compressed = pako.gzip(data);
 - const decompressed = pako.ungzip(compressed);
-+ import { gzipCompress, gzipDecompress } from 'comprs';
++ import { gzipCompress, gzipDecompress } from '@derodero24/comprs';
 + const compressed = gzipCompress(data);
 + const decompressed = gzipDecompress(compressed);
 ```
@@ -492,7 +492,7 @@ On the client side, comprs automatically falls back to WASM — no additional co
 - import { gzipSync, gunzipSync } from 'fflate';
 - const compressed = gzipSync(data);
 - const decompressed = gunzipSync(compressed);
-+ import { gzipCompress, gzipDecompress } from 'comprs';
++ import { gzipCompress, gzipDecompress } from '@derodero24/comprs';
 + const compressed = gzipCompress(data);
 + const decompressed = gzipDecompress(compressed);
 ```
@@ -505,7 +505,7 @@ comprs adds zstd, lz4, brotli, dictionary compression, and Web Streams API — n
 - import { gzipSync, gunzipSync } from 'node:zlib';
 - const compressed = gzipSync(data);
 - const decompressed = gunzipSync(compressed);
-+ import { gzipCompress, gzipDecompress } from 'comprs';
++ import { gzipCompress, gzipDecompress } from '@derodero24/comprs';
 + const compressed = gzipCompress(data);
 + const decompressed = gzipDecompress(compressed);
 ```

--- a/browser.js
+++ b/browser.js
@@ -1,1 +1,1 @@
-export * from 'comprs-wasm32-wasi'
+export * from '@derodero24/comprs-wasm32-wasi'

--- a/index.js
+++ b/index.js
@@ -75,8 +75,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('comprs-android-arm64')
-        const bindingPackageVersion = require('comprs-android-arm64/package.json').version
+        const binding = require('@derodero24/comprs-android-arm64')
+        const bindingPackageVersion = require('@derodero24/comprs-android-arm64/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -91,8 +91,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('comprs-android-arm-eabi')
-        const bindingPackageVersion = require('comprs-android-arm-eabi/package.json').version
+        const binding = require('@derodero24/comprs-android-arm-eabi')
+        const bindingPackageVersion = require('@derodero24/comprs-android-arm-eabi/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -112,8 +112,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('comprs-win32-x64-gnu')
-        const bindingPackageVersion = require('comprs-win32-x64-gnu/package.json').version
+        const binding = require('@derodero24/comprs-win32-x64-gnu')
+        const bindingPackageVersion = require('@derodero24/comprs-win32-x64-gnu/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -128,8 +128,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('comprs-win32-x64-msvc')
-        const bindingPackageVersion = require('comprs-win32-x64-msvc/package.json').version
+        const binding = require('@derodero24/comprs-win32-x64-msvc')
+        const bindingPackageVersion = require('@derodero24/comprs-win32-x64-msvc/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -145,8 +145,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('comprs-win32-ia32-msvc')
-        const bindingPackageVersion = require('comprs-win32-ia32-msvc/package.json').version
+        const binding = require('@derodero24/comprs-win32-ia32-msvc')
+        const bindingPackageVersion = require('@derodero24/comprs-win32-ia32-msvc/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -161,8 +161,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('comprs-win32-arm64-msvc')
-        const bindingPackageVersion = require('comprs-win32-arm64-msvc/package.json').version
+        const binding = require('@derodero24/comprs-win32-arm64-msvc')
+        const bindingPackageVersion = require('@derodero24/comprs-win32-arm64-msvc/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -180,8 +180,8 @@ function requireNative() {
       loadErrors.push(e)
     }
     try {
-      const binding = require('comprs-darwin-universal')
-      const bindingPackageVersion = require('comprs-darwin-universal/package.json').version
+      const binding = require('@derodero24/comprs-darwin-universal')
+      const bindingPackageVersion = require('@derodero24/comprs-darwin-universal/package.json').version
       if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
         throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
@@ -196,8 +196,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('comprs-darwin-x64')
-        const bindingPackageVersion = require('comprs-darwin-x64/package.json').version
+        const binding = require('@derodero24/comprs-darwin-x64')
+        const bindingPackageVersion = require('@derodero24/comprs-darwin-x64/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -212,8 +212,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('comprs-darwin-arm64')
-        const bindingPackageVersion = require('comprs-darwin-arm64/package.json').version
+        const binding = require('@derodero24/comprs-darwin-arm64')
+        const bindingPackageVersion = require('@derodero24/comprs-darwin-arm64/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -232,8 +232,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('comprs-freebsd-x64')
-        const bindingPackageVersion = require('comprs-freebsd-x64/package.json').version
+        const binding = require('@derodero24/comprs-freebsd-x64')
+        const bindingPackageVersion = require('@derodero24/comprs-freebsd-x64/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -248,8 +248,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('comprs-freebsd-arm64')
-        const bindingPackageVersion = require('comprs-freebsd-arm64/package.json').version
+        const binding = require('@derodero24/comprs-freebsd-arm64')
+        const bindingPackageVersion = require('@derodero24/comprs-freebsd-arm64/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -269,8 +269,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('comprs-linux-x64-musl')
-          const bindingPackageVersion = require('comprs-linux-x64-musl/package.json').version
+          const binding = require('@derodero24/comprs-linux-x64-musl')
+          const bindingPackageVersion = require('@derodero24/comprs-linux-x64-musl/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -285,8 +285,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('comprs-linux-x64-gnu')
-          const bindingPackageVersion = require('comprs-linux-x64-gnu/package.json').version
+          const binding = require('@derodero24/comprs-linux-x64-gnu')
+          const bindingPackageVersion = require('@derodero24/comprs-linux-x64-gnu/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -303,8 +303,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('comprs-linux-arm64-musl')
-          const bindingPackageVersion = require('comprs-linux-arm64-musl/package.json').version
+          const binding = require('@derodero24/comprs-linux-arm64-musl')
+          const bindingPackageVersion = require('@derodero24/comprs-linux-arm64-musl/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -319,8 +319,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('comprs-linux-arm64-gnu')
-          const bindingPackageVersion = require('comprs-linux-arm64-gnu/package.json').version
+          const binding = require('@derodero24/comprs-linux-arm64-gnu')
+          const bindingPackageVersion = require('@derodero24/comprs-linux-arm64-gnu/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -337,8 +337,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('comprs-linux-arm-musleabihf')
-          const bindingPackageVersion = require('comprs-linux-arm-musleabihf/package.json').version
+          const binding = require('@derodero24/comprs-linux-arm-musleabihf')
+          const bindingPackageVersion = require('@derodero24/comprs-linux-arm-musleabihf/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -353,8 +353,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('comprs-linux-arm-gnueabihf')
-          const bindingPackageVersion = require('comprs-linux-arm-gnueabihf/package.json').version
+          const binding = require('@derodero24/comprs-linux-arm-gnueabihf')
+          const bindingPackageVersion = require('@derodero24/comprs-linux-arm-gnueabihf/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -371,8 +371,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('comprs-linux-loong64-musl')
-          const bindingPackageVersion = require('comprs-linux-loong64-musl/package.json').version
+          const binding = require('@derodero24/comprs-linux-loong64-musl')
+          const bindingPackageVersion = require('@derodero24/comprs-linux-loong64-musl/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -387,8 +387,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('comprs-linux-loong64-gnu')
-          const bindingPackageVersion = require('comprs-linux-loong64-gnu/package.json').version
+          const binding = require('@derodero24/comprs-linux-loong64-gnu')
+          const bindingPackageVersion = require('@derodero24/comprs-linux-loong64-gnu/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -405,8 +405,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('comprs-linux-riscv64-musl')
-          const bindingPackageVersion = require('comprs-linux-riscv64-musl/package.json').version
+          const binding = require('@derodero24/comprs-linux-riscv64-musl')
+          const bindingPackageVersion = require('@derodero24/comprs-linux-riscv64-musl/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -421,8 +421,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('comprs-linux-riscv64-gnu')
-          const bindingPackageVersion = require('comprs-linux-riscv64-gnu/package.json').version
+          const binding = require('@derodero24/comprs-linux-riscv64-gnu')
+          const bindingPackageVersion = require('@derodero24/comprs-linux-riscv64-gnu/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -438,8 +438,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('comprs-linux-ppc64-gnu')
-        const bindingPackageVersion = require('comprs-linux-ppc64-gnu/package.json').version
+        const binding = require('@derodero24/comprs-linux-ppc64-gnu')
+        const bindingPackageVersion = require('@derodero24/comprs-linux-ppc64-gnu/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -454,8 +454,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('comprs-linux-s390x-gnu')
-        const bindingPackageVersion = require('comprs-linux-s390x-gnu/package.json').version
+        const binding = require('@derodero24/comprs-linux-s390x-gnu')
+        const bindingPackageVersion = require('@derodero24/comprs-linux-s390x-gnu/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -474,8 +474,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('comprs-openharmony-arm64')
-        const bindingPackageVersion = require('comprs-openharmony-arm64/package.json').version
+        const binding = require('@derodero24/comprs-openharmony-arm64')
+        const bindingPackageVersion = require('@derodero24/comprs-openharmony-arm64/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -490,8 +490,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('comprs-openharmony-x64')
-        const bindingPackageVersion = require('comprs-openharmony-x64/package.json').version
+        const binding = require('@derodero24/comprs-openharmony-x64')
+        const bindingPackageVersion = require('@derodero24/comprs-openharmony-x64/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -506,8 +506,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('comprs-openharmony-arm')
-        const bindingPackageVersion = require('comprs-openharmony-arm/package.json').version
+        const binding = require('@derodero24/comprs-openharmony-arm')
+        const bindingPackageVersion = require('@derodero24/comprs-openharmony-arm/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -538,7 +538,7 @@ if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
   }
   if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
     try {
-      wasiBinding = require('comprs-wasm32-wasi')
+      wasiBinding = require('@derodero24/comprs-wasm32-wasi')
       nativeBinding = wasiBinding
     } catch (err) {
       if (process.env.NAPI_RS_FORCE_WASI) {

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "comprs-darwin-arm64",
+  "name": "@derodero24/comprs-darwin-arm64",
   "version": "0.4.0",
   "cpu": [
     "arm64"

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "comprs-darwin-x64",
+  "name": "@derodero24/comprs-darwin-x64",
   "version": "0.4.0",
   "cpu": [
     "x64"

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "comprs-linux-arm64-gnu",
+  "name": "@derodero24/comprs-linux-arm64-gnu",
   "version": "0.4.0",
   "cpu": [
     "arm64"

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "comprs-linux-arm64-musl",
+  "name": "@derodero24/comprs-linux-arm64-musl",
   "version": "0.4.0",
   "cpu": [
     "arm64"

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "comprs-linux-x64-gnu",
+  "name": "@derodero24/comprs-linux-x64-gnu",
   "version": "0.4.0",
   "cpu": [
     "x64"

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "comprs-linux-x64-musl",
+  "name": "@derodero24/comprs-linux-x64-musl",
   "version": "0.4.0",
   "cpu": [
     "x64"

--- a/npm/wasm32-wasi/package.json
+++ b/npm/wasm32-wasi/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "comprs-wasm32-wasi",
+  "name": "@derodero24/comprs-wasm32-wasi",
   "version": "0.4.0",
   "cpu": [
     "wasm32"

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "comprs-win32-arm64-msvc",
+  "name": "@derodero24/comprs-win32-arm64-msvc",
   "version": "0.4.0",
   "cpu": [
     "arm64"

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "comprs-win32-x64-msvc",
+  "name": "@derodero24/comprs-win32-x64-msvc",
   "version": "0.4.0",
   "cpu": [
     "x64"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "comprs",
+  "name": "@derodero24/comprs",
   "version": "0.4.0",
   "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, brotli, and lz4 in one package.",
   "license": "MIT",

--- a/playground/index.html
+++ b/playground/index.html
@@ -31,7 +31,7 @@
       </div>
       <nav class="header-nav">
         <a href="https://github.com/derodero24/comprs" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://www.npmjs.com/package/comprs" target="_blank" rel="noopener">npm</a>
+        <a href="https://www.npmjs.com/package/@derodero24/comprs" target="_blank" rel="noopener">npm</a>
         <a href="https://github.com/derodero24/comprs#readme" target="_blank" rel="noopener">Docs</a>
       </nav>
     </div>
@@ -124,7 +124,7 @@
       <p>
         <a href="https://github.com/derodero24/comprs" target="_blank" rel="noopener">GitHub</a>
         ·
-        <a href="https://www.npmjs.com/package/comprs" target="_blank" rel="noopener">npm</a>
+        <a href="https://www.npmjs.com/package/@derodero24/comprs" target="_blank" rel="noopener">npm</a>
         ·
         Rust-powered · Zero JS dependencies
       </p>


### PR DESCRIPTION
## Summary
- Rename all npm packages from `comprs-*` to `@derodero24/comprs-*` to bypass npm's typosquatting protection
- Regenerate napi-rs generated files with new scoped package names
- Update README install/import examples
- Update release workflow version checks
- Update playground npm link

## Context
The `comprs` package name was blocked by npm's typosquatting protection (`403 Forbidden - Package name too similar to existing packages cors,colors`). Scoped packages (`@derodero24/comprs`) are exempt from this check. Test publish verified at `0.0.0-test.1`.

Closes #297

## Checklist
- [x] Root `package.json` name updated
- [x] All 9 `npm/*/package.json` names updated
- [x] `index.js`, `browser.js` regenerated via `pnpm run build`
- [x] `release.yml` version check updated to use scoped name
- [x] `README.md` install/import examples updated
- [x] `playground/index.html` npm links updated
- [x] All checks pass (lint, typecheck, test, cargo test, clippy)