### PR TITLE
fix(ci): add publishConfig and permissions for scoped npm publish

### DIFF
--- a/.changeset/fix-publish-config.md
+++ b/.changeset/fix-publish-config.md
@@ -1,0 +1,5 @@
+---
+"@derodero24/comprs": patch
+---
+
+Fix npm publish for scoped platform packages by adding publishConfig and release workflow permissions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm-publish
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -35,5 +35,9 @@
   },
   "os": [
     "darwin"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
 }

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -35,5 +35,9 @@
   },
   "os": [
     "darwin"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
 }

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -38,5 +38,9 @@
   ],
   "libc": [
     "glibc"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
 }

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -38,5 +38,9 @@
   ],
   "libc": [
     "musl"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
 }

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -38,5 +38,9 @@
   ],
   "libc": [
     "glibc"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
 }

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -38,5 +38,9 @@
   ],
   "libc": [
     "musl"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
 }

--- a/npm/wasm32-wasi/package.json
+++ b/npm/wasm32-wasi/package.json
@@ -40,5 +40,9 @@
   "browser": "comprs.wasi-browser.js",
   "dependencies": {
     "@napi-rs/wasm-runtime": "^1.1.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -35,5 +35,9 @@
   },
   "os": [
     "win32"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
 }

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -35,5 +35,9 @@
   },
   "os": [
     "win32"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -163,5 +163,9 @@
         "@codspeed/vitest-plugin>vite": "8"
       }
     }
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
## Summary
- Add `publishConfig.access: "public"` to root and all 9 platform `package.json` files
- Add `contents: write` permission to Publish job in release workflow
- Add changeset for v0.4.1 patch release

## Root cause of v0.4.0 partial publish failure

1. **Missing `publishConfig`**: `napi prepublish` runs bare `npm publish` for each platform package, but scoped packages default to restricted. `publishConfig.access: "public"` is the standard fix used by @napi-rs/canvas, oxc, and rolldown.

2. **Insufficient permissions**: `napi prepublish -t npm` creates a GitHub Release by default, requiring `contents: write`. The Publish job only had `contents: read`.

## Verification
- [x] `publishConfig` verified in all 10 package.json files
- [x] `napi prepublish -t npm --dry-run --no-gh-release` passes locally
- [x] All checks pass (lint, typecheck, test, cargo test, clippy)

Closes #301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * スコープ付きパッケージのnpm公開設定を修正しました。

* **Chores**
  * リリースワークフローの権限設定を更新しました。
  * npm公開設定をすべてのプラットフォームパッケージに統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->