### PR TITLE
fix: update stale package references after rename to @derodero24/comprs

### DIFF
--- a/browser-streaming.js
+++ b/browser-streaming.js
@@ -21,7 +21,7 @@ import {
   zstdCompressWithDict as _zstdCompressWithDict,
   zstdDecompressWithDict as _zstdDecompressWithDict,
   zstdDecompressWithDictWithCapacity as _zstdDecompressWithDictWithCapacity,
-} from 'comprs-wasm32-wasi'
+} from '@derodero24/comprs-wasm32-wasi'
 
 /**
  * Concatenate an array of Uint8Array chunks into a single Uint8Array.

--- a/playground/main.js
+++ b/playground/main.js
@@ -19,7 +19,7 @@ const {
   lz4Decompress,
   zstdCompress,
   zstdDecompress,
-} = await import('comprs');
+} = await import('@derodero24/comprs');
 
 // --- Sample data ---
 const SAMPLES = {

--- a/playground/package.json
+++ b/playground/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "buffer": "^6.0.3",
-    "comprs": "file:.."
+    "@derodero24/comprs": "file:.."
   },
   "devDependencies": {
     "vite": "^8.0.0"

--- a/playground/vite.config.js
+++ b/playground/vite.config.js
@@ -33,13 +33,13 @@ export default defineConfig({
   resolve: {
     alias: hasLocalWasm
       ? {
-          // Real WASM: point comprs to browser entry + use local WASM build
-          comprs: browserEntry,
+          // Real WASM: point @derodero24/comprs to browser entry + use local WASM build
+          '@derodero24/comprs': browserEntry,
           '@derodero24/comprs-wasm32-wasi': localWasmEntry,
         }
       : {
           // Dev mock: bypass WASM entirely with a JS fallback
-          comprs: mockEntry,
+          '@derodero24/comprs': mockEntry,
         },
   },
 });


### PR DESCRIPTION
## Summary
Update 4 files with stale unscoped package references that were missed in #298:

- `browser-streaming.js`: `comprs-wasm32-wasi` → `@derodero24/comprs-wasm32-wasi`
- `playground/main.js`: `import('comprs')` → `import('@derodero24/comprs')`
- `playground/package.json`: dependency name updated
- `playground/vite.config.js`: Vite alias keys updated

## Context
This fixes the GitHub Pages deployment failure that started after the package rename. The `browser-streaming.js` import of the old unscoped WASM package name caused Vite's production build to fail with an unresolved import error.

Closes #306

## Checklist
- [x] All stale references updated (verified via grep)
- [x] All checks pass (lint, typecheck, test, cargo test, clippy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores（保守作業）**
  * 内部パッケージ参照を更新し、依存関係管理を最適化しました。複数の設定ファイルと構成にわたって一貫性のある参照を確保しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->