### PR TITLE
fix: update npm badges and sub-package descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 Rust-powered universal compression for JavaScript/TypeScript.
 **zstd**, **gzip**, **brotli**, and **lz4** in one package.
 
-[![npm version](https://img.shields.io/npm/v/comprs)](https://www.npmjs.com/package/comprs)
-[![npm downloads](https://img.shields.io/npm/dm/comprs)](https://www.npmjs.com/package/comprs)
+[![npm version](https://img.shields.io/npm/v/%40derodero24%2Fcomprs)](https://www.npmjs.com/package/@derodero24/comprs)
+[![npm downloads](https://img.shields.io/npm/dm/%40derodero24%2Fcomprs)](https://www.npmjs.com/package/@derodero24/comprs)
 [![CI](https://github.com/derodero24/comprs/actions/workflows/ci.yml/badge.svg)](https://github.com/derodero24/comprs/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/derodero24/comprs/graph/badge.svg)](https://codecov.io/gh/derodero24/comprs)
 [![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json&repo=derodero24/comprs)](https://codspeed.io/derodero24/comprs)

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -8,7 +8,7 @@
   "files": [
     "comprs.darwin-arm64.node"
   ],
-  "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, and brotli in one package.",
+  "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, brotli, and lz4 in one package.",
   "keywords": [
     "compression",
     "zstd",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -8,7 +8,7 @@
   "files": [
     "comprs.darwin-x64.node"
   ],
-  "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, and brotli in one package.",
+  "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, brotli, and lz4 in one package.",
   "keywords": [
     "compression",
     "zstd",

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -8,7 +8,7 @@
   "files": [
     "comprs.linux-arm64-gnu.node"
   ],
-  "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, and brotli in one package.",
+  "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, brotli, and lz4 in one package.",
   "keywords": [
     "compression",
     "zstd",

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -8,7 +8,7 @@
   "files": [
     "comprs.linux-arm64-musl.node"
   ],
-  "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, and brotli in one package.",
+  "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, brotli, and lz4 in one package.",
   "keywords": [
     "compression",
     "zstd",

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -8,7 +8,7 @@
   "files": [
     "comprs.linux-x64-gnu.node"
   ],
-  "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, and brotli in one package.",
+  "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, brotli, and lz4 in one package.",
   "keywords": [
     "compression",
     "zstd",

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -8,7 +8,7 @@
   "files": [
     "comprs.linux-x64-musl.node"
   ],
-  "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, and brotli in one package.",
+  "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, brotli, and lz4 in one package.",
   "keywords": [
     "compression",
     "zstd",

--- a/npm/wasm32-wasi/package.json
+++ b/npm/wasm32-wasi/package.json
@@ -12,7 +12,7 @@
     "wasi-worker.mjs",
     "wasi-worker-browser.mjs"
   ],
-  "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, and brotli in one package.",
+  "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, brotli, and lz4 in one package.",
   "keywords": [
     "compression",
     "zstd",

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -8,7 +8,7 @@
   "files": [
     "comprs.win32-arm64-msvc.node"
   ],
-  "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, and brotli in one package.",
+  "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, brotli, and lz4 in one package.",
   "keywords": [
     "compression",
     "zstd",

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -8,7 +8,7 @@
   "files": [
     "comprs.win32-x64-msvc.node"
   ],
-  "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, and brotli in one package.",
+  "description": "Rust-powered universal compression for JavaScript/TypeScript. zstd, gzip, brotli, and lz4 in one package.",
   "keywords": [
     "compression",
     "zstd",


### PR DESCRIPTION
## Summary
- Update README npm version/downloads badge URLs to use the scoped package name `@derodero24/comprs` instead of the old unscoped `comprs`
- Update all 9 platform sub-package descriptions in `npm/*/package.json` to include "lz4", matching the root package.json

## Related issues
Closes #312
Closes #315

## Checklist
- [x] README badge URLs point to `@derodero24/comprs`
- [x] All 9 `npm/*/package.json` descriptions updated to "zstd, gzip, brotli, and lz4 in one package."
- [x] Lint, typecheck, cargo test, cargo clippy all pass
- [x] No code changes — metadata/docs only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * パッケージリポジトリへのリンク表示を更新しました。

* **Chores**
  * サポートされている圧縮形式の一覧にlz4を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->