### PR TITLE
fix: add missing ESM export and test coverage

### DIFF
--- a/__test__/brotli-dict.spec.ts
+++ b/__test__/brotli-dict.spec.ts
@@ -5,6 +5,8 @@ import {
   brotliCompressWithDictAsync,
   brotliDecompressWithDict,
   brotliDecompressWithDictAsync,
+  brotliDecompressWithDictWithCapacity,
+  brotliDecompressWithDictWithCapacityAsync,
 } from '../index.js';
 import { createBrotliCompressDictStream, createBrotliDecompressDictStream } from '../streams.js';
 
@@ -92,6 +94,108 @@ describe('brotli dictionary compression', () => {
     const compressed = await brotliCompressWithDictAsync(original, dict);
     const decompressed = await brotliDecompressWithDictAsync(compressed, dict);
     expect(Buffer.compare(decompressed, original)).toBe(0);
+  });
+});
+
+describe('brotliDecompressWithDictWithCapacity', () => {
+  const dict = buildDict();
+
+  it('should decompress with exact capacity', () => {
+    const original = Buffer.from(
+      JSON.stringify({
+        id: 999,
+        name: 'capacity_test',
+        email: 'capacity@example.com',
+        active: true,
+      }),
+    );
+    const compressed = brotliCompressWithDict(original, dict);
+    const decompressed = brotliDecompressWithDictWithCapacity(compressed, dict, original.length);
+    expect(Buffer.compare(decompressed, original)).toBe(0);
+  });
+
+  it('should decompress with oversized capacity', () => {
+    const original = Buffer.from(
+      JSON.stringify({
+        id: 888,
+        name: 'oversized_test',
+        email: 'oversized@example.com',
+        active: false,
+      }),
+    );
+    const compressed = brotliCompressWithDict(original, dict);
+    const decompressed = brotliDecompressWithDictWithCapacity(
+      compressed,
+      dict,
+      original.length * 10,
+    );
+    expect(Buffer.compare(decompressed, original)).toBe(0);
+  });
+
+  it('should throw with insufficient capacity', () => {
+    const original = Buffer.from(
+      JSON.stringify({
+        id: 777,
+        name: 'insufficient_test',
+        email: 'insufficient@example.com',
+        active: true,
+      }),
+    );
+    const compressed = brotliCompressWithDict(original, dict);
+    expect(() => brotliDecompressWithDictWithCapacity(compressed, dict, 1)).toThrow();
+  });
+});
+
+describe('brotliDecompressWithDictWithCapacityAsync', () => {
+  const dict = buildDict();
+
+  it('should decompress async with exact capacity', async () => {
+    const original = Buffer.from(
+      JSON.stringify({
+        id: 999,
+        name: 'async_capacity_test',
+        email: 'async_capacity@example.com',
+        active: true,
+      }),
+    );
+    const compressed = brotliCompressWithDict(original, dict);
+    const decompressed = await brotliDecompressWithDictWithCapacityAsync(
+      compressed,
+      dict,
+      original.length,
+    );
+    expect(Buffer.compare(decompressed, original)).toBe(0);
+  });
+
+  it('should decompress async with oversized capacity', async () => {
+    const original = Buffer.from(
+      JSON.stringify({
+        id: 888,
+        name: 'async_oversized_test',
+        email: 'async_oversized@example.com',
+        active: false,
+      }),
+    );
+    const compressed = brotliCompressWithDict(original, dict);
+    const decompressed = await brotliDecompressWithDictWithCapacityAsync(
+      compressed,
+      dict,
+      original.length * 10,
+    );
+    expect(Buffer.compare(decompressed, original)).toBe(0);
+  });
+
+  it('should reject with insufficient capacity', async () => {
+    const original = Buffer.from(
+      JSON.stringify({
+        id: 777,
+        name: 'async_insufficient_test',
+        email: 'async_insufficient@example.com',
+        active: true,
+      }),
+    );
+    const compressed = brotliCompressWithDict(original, dict);
+    await expect(brotliDecompressWithDictWithCapacityAsync(compressed, dict, 1)).rejects.toThrow();
   });
 });
 

--- a/__test__/esm-import.mjs
+++ b/__test__/esm-import.mjs
@@ -63,6 +63,7 @@ import {
   zstdDecompressWithCapacityAsync,
   zstdDecompressWithDict,
   zstdDecompressWithDictAsync,
+  zstdDecompressWithDictWithCapacity,
   zstdTrainDictionary,
   zstdTrainDictionaryAsync,
 } from '../index.mjs';
@@ -188,6 +189,11 @@ assert.strictEqual(
   typeof zstdDecompressWithDictAsync,
   'function',
   'zstdDecompressWithDictAsync should be a function',
+);
+assert.strictEqual(
+  typeof zstdDecompressWithDictWithCapacity,
+  'function',
+  'zstdDecompressWithDictWithCapacity should be a function',
 );
 assert.strictEqual(typeof zstdCompressAsync, 'function', 'zstdCompressAsync should be a function');
 assert.strictEqual(

--- a/__test__/node-streams.spec.ts
+++ b/__test__/node-streams.spec.ts
@@ -5,22 +5,35 @@ import { pipeline } from 'node:stream/promises';
 import { describe, expect, it } from 'vitest';
 import {
   brotliCompress,
+  brotliCompressWithDict,
   brotliDecompress,
+  brotliDecompressWithDict,
   deflateCompress,
   deflateDecompress,
   gzipCompress,
   gzipDecompress,
+  lz4Compress,
+  lz4Decompress,
   zstdCompress,
+  zstdCompressWithDict,
   zstdDecompress,
+  zstdDecompressWithDict,
+  zstdTrainDictionary,
 } from '../index.js';
 import {
+  createBrotliCompressDictTransform,
   createBrotliCompressTransform,
+  createBrotliDecompressDictTransform,
   createBrotliDecompressTransform,
   createDeflateCompressTransform,
   createDeflateDecompressTransform,
   createGzipCompressTransform,
   createGzipDecompressTransform,
+  createLz4CompressTransform,
+  createLz4DecompressTransform,
+  createZstdCompressDictTransform,
   createZstdCompressTransform,
+  createZstdDecompressDictTransform,
   createZstdDecompressTransform,
 } from '../node.js';
 
@@ -373,6 +386,171 @@ describe('brotli node stream round-trip', () => {
     const source = toChunkedReadable(data, 64);
     const compressed = await collectTransform(source, createBrotliCompressTransform());
     const decompressed = brotliDecompress(compressed);
+    expect(Buffer.compare(decompressed, data)).toBe(0);
+  });
+});
+
+describe('lz4 node stream round-trip', () => {
+  it('should compress then decompress through pipeline', async () => {
+    const data = Buffer.from('Piped lz4 node stream test '.repeat(200));
+    const source = toChunkedReadable(data, 128);
+    const result = await collectTransform2(
+      source,
+      createLz4CompressTransform(),
+      createLz4DecompressTransform(),
+    );
+    expect(Buffer.compare(result, data)).toBe(0);
+  });
+
+  it('should handle small chunks', async () => {
+    const data = Buffer.from('LZ4 small chunk test '.repeat(100));
+    const source = toChunkedReadable(data, 16);
+    const result = await collectTransform2(
+      source,
+      createLz4CompressTransform(),
+      createLz4DecompressTransform(),
+    );
+    expect(Buffer.compare(result, data)).toBe(0);
+  });
+
+  it('should interop with one-shot compress', async () => {
+    const data = Buffer.from('LZ4 interop test data '.repeat(50));
+    const oneShotCompressed = Buffer.from(lz4Compress(data));
+    const source = toChunkedReadable(oneShotCompressed, 32);
+    const result = await collectTransform(source, createLz4DecompressTransform());
+    expect(Buffer.compare(result, data)).toBe(0);
+  });
+
+  it('should interop with one-shot decompress', async () => {
+    const data = Buffer.from('LZ4 interop test data '.repeat(50));
+    const source = toChunkedReadable(data, 64);
+    const compressed = await collectTransform(source, createLz4CompressTransform());
+    const decompressed = lz4Decompress(compressed);
+    expect(Buffer.compare(decompressed, data)).toBe(0);
+  });
+});
+
+describe('zstd dict node stream round-trip', () => {
+  const samples = Array.from({ length: 100 }, (_, i) =>
+    Buffer.from(
+      JSON.stringify({
+        id: i,
+        name: `user_${i}`,
+        email: `user${i}@example.com`,
+        active: i % 2 === 0,
+      }),
+    ),
+  );
+
+  it('should compress then decompress through pipeline with dict', async () => {
+    const dict = zstdTrainDictionary(samples);
+    const data = Buffer.from(
+      JSON.stringify({
+        id: 500,
+        name: 'dict_stream_user',
+        email: 'dict_stream@example.com',
+        active: true,
+      }),
+    );
+    const source = toChunkedReadable(data, 32);
+    const result = await collectTransform2(
+      source,
+      createZstdCompressDictTransform(dict),
+      createZstdDecompressDictTransform(dict),
+    );
+    expect(Buffer.compare(result, data)).toBe(0);
+  });
+
+  it('should interop with one-shot dict compress', async () => {
+    const dict = zstdTrainDictionary(samples);
+    const data = Buffer.from(
+      JSON.stringify({
+        id: 123,
+        name: 'interop_dict_user',
+        email: 'interop_dict@example.com',
+        active: false,
+      }),
+    );
+    const oneShotCompressed = Buffer.from(zstdCompressWithDict(data, dict));
+    const source = toChunkedReadable(oneShotCompressed, 16);
+    const result = await collectTransform(source, createZstdDecompressDictTransform(dict));
+    expect(Buffer.compare(result, data)).toBe(0);
+  });
+
+  it('should interop with one-shot dict decompress', async () => {
+    const dict = zstdTrainDictionary(samples);
+    const data = Buffer.from(
+      JSON.stringify({
+        id: 456,
+        name: 'interop_dict_user_2',
+        email: 'interop_dict2@example.com',
+        active: true,
+      }),
+    );
+    const source = toChunkedReadable(data, 32);
+    const compressed = await collectTransform(source, createZstdCompressDictTransform(dict));
+    const decompressed = zstdDecompressWithDict(compressed, dict);
+    expect(Buffer.compare(decompressed, data)).toBe(0);
+  });
+});
+
+describe('brotli dict node stream round-trip', () => {
+  const dict = Buffer.from(
+    Array.from({ length: 20 }, (_, i) =>
+      JSON.stringify({
+        id: i,
+        name: `user_${i}`,
+        email: `user${i}@example.com`,
+        active: i % 2 === 0,
+      }),
+    ).join(''),
+  );
+
+  it('should compress then decompress through pipeline with dict', async () => {
+    const data = Buffer.from(
+      JSON.stringify({
+        id: 500,
+        name: 'dict_stream_user',
+        email: 'dict_stream@example.com',
+        active: true,
+      }),
+    );
+    const source = toChunkedReadable(data, 32);
+    const result = await collectTransform2(
+      source,
+      createBrotliCompressDictTransform(dict),
+      createBrotliDecompressDictTransform(dict),
+    );
+    expect(Buffer.compare(result, data)).toBe(0);
+  });
+
+  it('should interop with one-shot dict compress', async () => {
+    const data = Buffer.from(
+      JSON.stringify({
+        id: 123,
+        name: 'interop_dict_user',
+        email: 'interop_dict@example.com',
+        active: false,
+      }),
+    );
+    const oneShotCompressed = Buffer.from(brotliCompressWithDict(data, dict));
+    const source = toChunkedReadable(oneShotCompressed, 16);
+    const result = await collectTransform(source, createBrotliDecompressDictTransform(dict));
+    expect(Buffer.compare(result, data)).toBe(0);
+  });
+
+  it('should interop with one-shot dict decompress', async () => {
+    const data = Buffer.from(
+      JSON.stringify({
+        id: 456,
+        name: 'interop_dict_user_2',
+        email: 'interop_dict2@example.com',
+        active: true,
+      }),
+    );
+    const source = toChunkedReadable(data, 32);
+    const compressed = await collectTransform(source, createBrotliCompressDictTransform(dict));
+    const decompressed = brotliDecompressWithDict(compressed, dict);
     expect(Buffer.compare(decompressed, data)).toBe(0);
   });
 });

--- a/__test__/zstd-dict.spec.ts
+++ b/__test__/zstd-dict.spec.ts
@@ -4,6 +4,7 @@ import {
   zstdCompress,
   zstdCompressWithDict,
   zstdDecompressWithDict,
+  zstdDecompressWithDictWithCapacity,
   zstdTrainDictionary,
 } from '../index.js';
 import { createZstdCompressDictStream, createZstdDecompressDictStream } from '../streams.js';
@@ -79,6 +80,63 @@ describe('zstd dictionary compression', () => {
     const withDict = zstdCompressWithDict(small, dict);
     const withoutDict = zstdCompress(small);
     expect(withDict.length).toBeLessThan(withoutDict.length);
+  });
+});
+
+describe('zstdDecompressWithDictWithCapacity', () => {
+  const samples = Array.from({ length: 100 }, (_, i) =>
+    Buffer.from(
+      JSON.stringify({
+        id: i,
+        name: `user_${i}`,
+        email: `user${i}@example.com`,
+        active: i % 2 === 0,
+      }),
+    ),
+  );
+
+  it('should decompress with exact capacity', () => {
+    const dict = zstdTrainDictionary(samples);
+    const original = Buffer.from(
+      JSON.stringify({
+        id: 999,
+        name: 'capacity_test',
+        email: 'capacity@example.com',
+        active: true,
+      }),
+    );
+    const compressed = zstdCompressWithDict(original, dict);
+    const decompressed = zstdDecompressWithDictWithCapacity(compressed, dict, original.length);
+    expect(Buffer.compare(decompressed, original)).toBe(0);
+  });
+
+  it('should decompress with oversized capacity', () => {
+    const dict = zstdTrainDictionary(samples);
+    const original = Buffer.from(
+      JSON.stringify({
+        id: 888,
+        name: 'oversized_test',
+        email: 'oversized@example.com',
+        active: false,
+      }),
+    );
+    const compressed = zstdCompressWithDict(original, dict);
+    const decompressed = zstdDecompressWithDictWithCapacity(compressed, dict, original.length * 10);
+    expect(Buffer.compare(decompressed, original)).toBe(0);
+  });
+
+  it('should throw with insufficient capacity', () => {
+    const dict = zstdTrainDictionary(samples);
+    const original = Buffer.from(
+      JSON.stringify({
+        id: 777,
+        name: 'insufficient_test',
+        email: 'insufficient@example.com',
+        active: true,
+      }),
+    );
+    const compressed = zstdCompressWithDict(original, dict);
+    expect(() => zstdDecompressWithDictWithCapacity(compressed, dict, 1)).toThrow();
   });
 });
 

--- a/browser-entry.js
+++ b/browser-entry.js
@@ -53,6 +53,7 @@ export {
   zstdDecompressWithCapacityAsync,
   zstdDecompressWithDict,
   zstdDecompressWithDictAsync,
+  zstdDecompressWithDictWithCapacity,
   zstdTrainDictionary,
   zstdTrainDictionaryAsync,
 } from './browser.js'

--- a/index.mjs
+++ b/index.mjs
@@ -39,6 +39,7 @@ export const {
   zstdTrainDictionary,
   zstdCompressWithDict,
   zstdDecompressWithDict,
+  zstdDecompressWithDictWithCapacity,
   CompressionFormat,
   decompress,
   decompressAsync,


### PR DESCRIPTION
## Summary
- Add missing `zstdDecompressWithDictWithCapacity` to ESM (`index.mjs`) and browser (`browser-entry.js`) exports, plus ESM smoke test assertion
- Add test coverage for `zstdDecompressWithDictWithCapacity`, `brotliDecompressWithDictWithCapacity`, `brotliDecompressWithDictWithCapacityAsync`
- Add Node.js Transform stream round-trip tests for LZ4, zstd dict, and brotli dict

## Related issue
Closes #313
Closes #314

## Checklist
- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (459 tests)
- [x] `cargo test` passes (59 tests)
- [x] `cargo clippy` passes
- [x] `node __test__/esm-import.mjs` smoke test passes