### PR TITLE
chore: add changeset for v1.0.0 release

### DIFF
--- a/.changeset/v1-release.md
+++ b/.changeset/v1-release.md
@@ -1,0 +1,5 @@
+---
+"@derodero24/comprs": major
+---
+
+First stable release with wasm-bindgen browser support (no SharedArrayBuffer required), three-crate architecture, and full algorithm coverage (zstd, gzip, brotli, lz4)


### PR DESCRIPTION
Adds a major changeset to trigger v1.0.0 version bump via the changesets release flow.

Closes #321