### PR TITLE
fix: address post-release bugs in v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "comprs-core"
-version = "0.4.1"
+version = "1.0.0"
 dependencies = [
  "brotli",
  "crc32fast",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "comprs-wasm"
-version = "0.4.1"
+version = "1.0.0"
 dependencies = [
  "comprs-core",
  "js-sys",

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ const decompressed = await gzipDecompressAsync(compressed);
 | `zstdDecompressWithCapacityAsync(data, capacity)` | Async zstd decompression with explicit size limit |
 | `zstdCompressWithDictAsync(data, dict, level?)` | Async zstd compression with dictionary |
 | `zstdDecompressWithDictAsync(data, dict)` | Async zstd decompression with dictionary |
+| `zstdDecompressWithDictWithCapacityAsync(data, dict, capacity)` | Async zstd decompression with dictionary and size limit |
 | `zstdTrainDictionaryAsync(samples, maxDictSize?)` | Async dictionary training |
 | `gzipCompressAsync(data, level?)` | Async gzip compression |
 | `gzipDecompressAsync(data)` | Async gzip decompression |
@@ -314,6 +315,7 @@ const decompressed = await gzipDecompressAsync(compressed);
 | `brotliDecompressWithCapacityAsync(data, capacity)` | Async brotli decompression with explicit size limit |
 | `brotliCompressWithDictAsync(data, dict, quality?)` | Async brotli compression with dictionary |
 | `brotliDecompressWithDictAsync(data, dict)` | Async brotli decompression with dictionary |
+| `brotliDecompressWithDictWithCapacityAsync(data, dict, capacity)` | Async brotli decompression with dictionary and size limit |
 | `lz4CompressAsync(data)` | Async LZ4 compression |
 | `lz4DecompressAsync(data)` | Async LZ4 decompression |
 | `lz4DecompressWithCapacityAsync(data, capacity)` | Async LZ4 decompression with explicit size limit |

--- a/__test__/esm-import.mjs
+++ b/__test__/esm-import.mjs
@@ -64,6 +64,7 @@ import {
   zstdDecompressWithDict,
   zstdDecompressWithDictAsync,
   zstdDecompressWithDictWithCapacity,
+  zstdDecompressWithDictWithCapacityAsync,
   zstdTrainDictionary,
   zstdTrainDictionaryAsync,
 } from '../index.mjs';
@@ -194,6 +195,11 @@ assert.strictEqual(
   typeof zstdDecompressWithDictWithCapacity,
   'function',
   'zstdDecompressWithDictWithCapacity should be a function',
+);
+assert.strictEqual(
+  typeof zstdDecompressWithDictWithCapacityAsync,
+  'function',
+  'zstdDecompressWithDictWithCapacityAsync should be a function',
 );
 assert.strictEqual(typeof zstdCompressAsync, 'function', 'zstdCompressAsync should be a function');
 assert.strictEqual(

--- a/crates/core-lib/Cargo.toml
+++ b/crates/core-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comprs-core"
-version = "0.4.1"
+version = "1.0.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comprs-wasm"
-version = "0.4.1"
+version = "1.0.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/index.mjs
+++ b/index.mjs
@@ -40,6 +40,7 @@ export const {
   zstdCompressWithDict,
   zstdDecompressWithDict,
   zstdDecompressWithDictWithCapacity,
+  zstdDecompressWithDictWithCapacityAsync,
   CompressionFormat,
   decompress,
   decompressAsync,

--- a/scripts/sync-cargo-version.js
+++ b/scripts/sync-cargo-version.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Sync the version from package.json to crates/core/Cargo.toml.
+ * Sync the version from package.json to all Cargo.toml files.
  *
  * Run after `changeset version` to keep Cargo.toml in sync with package.json.
  * This is needed because changesets only manages npm package versions.
@@ -15,17 +15,26 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const PKG_PATH = path.resolve(__dirname, '..', 'package.json');
-const CARGO_PATH = path.resolve(__dirname, '..', 'crates', 'core', 'Cargo.toml');
+const CARGO_PATHS = [
+  path.resolve(__dirname, '..', 'crates', 'core', 'Cargo.toml'),
+  path.resolve(__dirname, '..', 'crates', 'core-lib', 'Cargo.toml'),
+  path.resolve(__dirname, '..', 'crates', 'wasm', 'Cargo.toml'),
+];
 
 const pkg = JSON.parse(fs.readFileSync(PKG_PATH, 'utf-8'));
 const version = pkg.version;
 
-const cargo = fs.readFileSync(CARGO_PATH, 'utf-8');
-const updated = cargo.replace(/^version\s*=\s*"[^"]*"/m, `version = "${version}"`);
+for (const cargoPath of CARGO_PATHS) {
+  if (!fs.existsSync(cargoPath)) continue;
 
-if (cargo === updated) {
-  console.log(`Cargo.toml already at version ${version}`);
-} else {
-  fs.writeFileSync(CARGO_PATH, updated);
-  console.log(`Synced Cargo.toml version to ${version}`);
+  const cargo = fs.readFileSync(cargoPath, 'utf-8');
+  const updated = cargo.replace(/^version\s*=\s*"[^"]*"/m, `version = "${version}"`);
+
+  const name = path.relative(path.resolve(__dirname, '..'), cargoPath);
+  if (cargo === updated) {
+    console.log(`${name} already at version ${version}`);
+  } else {
+    fs.writeFileSync(cargoPath, updated);
+    console.log(`Synced ${name} version to ${version}`);
+  }
 }


### PR DESCRIPTION
## Summary
Fix 4 bugs found in post-release audit of v1.0.0:

1. **`zstdDecompressWithDictWithCapacityAsync` missing from `index.mjs`** (High) — ESM users got `undefined` at runtime
2. **Version mismatch** (Medium) — `crates/core-lib` and `crates/wasm` still at `0.4.1`; sync script now covers all three Cargo.toml files
3. **README missing 2 async functions** in API list (Low)
4. **ESM smoke test** missing assertion for the function above

Closes #326

## Checklist
- [x] ESM smoke test passes with new assertion
- [x] All 459 JS tests + 73 Rust tests pass
- [x] All pre-push hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 非同期圧縮解除API（辞書とサイズ指定対応）をサポート
  * API ドキュメントを更新

* **Tests**
  * 新規 API 機能のテストカバレッジを追加

* **Chores**
  * メジャーバージョン（1.0.0）へ更新
  * ビルドスクリプトを改善し、複数マニフェストへの対応を強化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->