### PR TITLE
chore: add changeset for v1.0.1 patch release

### DIFF
--- a/.changeset/fix-post-release-bugs.md
+++ b/.changeset/fix-post-release-bugs.md
@@ -1,0 +1,5 @@
+---
+"@derodero24/comprs": patch
+---
+
+Fix missing zstdDecompressWithDictWithCapacityAsync ESM export and sync Cargo.toml versions


### PR DESCRIPTION
Adds a patch changeset for the bug fixes in #327 that were merged without a changeset.

This will trigger the changeset release flow to bump to v1.0.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* ESM エクスポートの不足を修正しました。
* パッケージバージョンの整合性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->