### PR TITLE
fix(playground): fix GitHub Pages deployment with wasm-bindgen

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,1 +1,1 @@
-export * from '@derodero24/comprs-wasm32-wasi'
+export * from './comprs-wasm.js'

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "postbuild:wasm-bindgen": "node scripts/optimize-wasm.js",
     "optimize:wasm": "node scripts/optimize-wasm.js",
     "artifacts": "napi artifacts",
-    "changeset:version": "changeset version && node scripts/sync-cargo-version.js && napi version && pnpm run build && pnpm run format",
+    "changeset:version": "changeset version && node scripts/sync-cargo-version.js && napi version && pnpm run build && node scripts/patch-browser-js.js && pnpm run format",
     "prepublishOnly": "napi prepublish -t npm",
     "version": "napi version",
     "check": "biome ci",

--- a/playground/main.js
+++ b/playground/main.js
@@ -1,15 +1,3 @@
-import { Buffer } from 'buffer';
-
-// emnapi (napi-rs WASM runtime) requires globalThis.Buffer when creating
-// memory views for WASM function arguments. Browsers do not define it natively.
-// Must be set BEFORE the comprs WASM module initializes (top-level await in
-// comprs-wasm32-wasi runs __emnapiInstantiateNapiModuleSync at import time).
-// Static imports are hoisted and evaluated before any module body code, so
-// a dynamic import is used to ensure Buffer is set first.
-if (!globalThis.Buffer) {
-  globalThis.Buffer = Buffer;
-}
-
 const {
   brotliCompress,
   brotliDecompress,

--- a/playground/vite.config.js
+++ b/playground/vite.config.js
@@ -8,7 +8,10 @@ import { defineConfig } from 'vite';
 const wasmBgFile = fileURLToPath(new URL('../comprs-wasm_bg.wasm', import.meta.url));
 const hasLocalWasm = existsSync(wasmBgFile);
 const mockEntry = fileURLToPath(new URL('./comprs-mock.js', import.meta.url));
-const browserEntry = fileURLToPath(new URL('../browser-entry.js', import.meta.url));
+
+// Use the playground's wasm-loader.js which manually instantiates the WASM binary.
+// This bypasses the ESM WASM import that Vite 8 does not support.
+const wasmLoader = fileURLToPath(new URL('./wasm-loader.js', import.meta.url));
 
 export default defineConfig({
   base: process.env.GITHUB_ACTIONS ? '/comprs/' : '/',
@@ -24,8 +27,8 @@ export default defineConfig({
   resolve: {
     alias: hasLocalWasm
       ? {
-          // Real WASM: point @derodero24/comprs to browser entry (which imports from ./comprs-wasm.js)
-          '@derodero24/comprs': browserEntry,
+          // Real WASM: use manual instantiation loader (Vite 8 ESM WASM workaround)
+          '@derodero24/comprs': wasmLoader,
         }
       : {
           // Dev mock: bypass WASM entirely with a JS fallback

--- a/playground/wasm-loader.js
+++ b/playground/wasm-loader.js
@@ -1,0 +1,34 @@
+/**
+ * WASM loader for the playground.
+ *
+ * Vite 8 does not support the TC39 WebAssembly ESM integration proposal
+ * (import * as wasm from './file.wasm'), so we cannot use comprs-wasm.js
+ * directly. Instead, import the background bindings and instantiate the
+ * WASM binary manually.
+ *
+ * This follows the same pattern used in rapid-fuzzy's e2e tests.
+ */
+
+// Import background bindings (no .wasm imports)
+import * as mod from '../comprs-wasm_bg.js';
+
+// Use Vite's ?url import to get a resolved URL for the WASM binary
+import wasmUrl from '../comprs-wasm_bg.wasm?url';
+
+const bytes = await fetch(wasmUrl).then((r) => r.arrayBuffer());
+const { instance } = await WebAssembly.instantiate(bytes, {
+  './comprs-wasm_bg.js': mod,
+});
+mod.__wbg_set_wasm(instance.exports);
+
+// Re-export only the functions used by the playground
+export const {
+  brotliCompress,
+  brotliDecompress,
+  gzipCompress,
+  gzipDecompress,
+  lz4Compress,
+  lz4Decompress,
+  zstdCompress,
+  zstdDecompress,
+} = mod;

--- a/scripts/build-wasm-bindgen.js
+++ b/scripts/build-wasm-bindgen.js
@@ -49,4 +49,8 @@ for (const file of files) {
 // Clean up wasm-pack output directory (it generates a package.json we don't want)
 rmSync(OUT_DIR, { recursive: true });
 
+// Patch browser.js — napi build/version regenerates this file to point at the
+// WASI WASM package, but we need it to point at the wasm-bindgen output.
+execSync('node scripts/patch-browser-js.js', { stdio: 'inherit', cwd: ROOT });
+
 console.log('Done.');

--- a/scripts/patch-browser-js.js
+++ b/scripts/patch-browser-js.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+/**
+ * Patch browser.js to use wasm-bindgen output.
+ *
+ * napi build/version regenerates browser.js to point at the WASI WASM package.
+ * This script overwrites it to use the wasm-bindgen output instead.
+ *
+ * Must be run after any napi build or napi version command.
+ */
+
+'use strict';
+
+const { writeFileSync } = require('node:fs');
+const { resolve } = require('node:path');
+
+const browserJsPath = resolve(__dirname, '..', 'browser.js');
+writeFileSync(browserJsPath, "export * from './comprs-wasm.js'\n");
+console.log('Patched browser.js → ./comprs-wasm.js');


### PR DESCRIPTION
## Summary

Fix GitHub Pages deployment that has been failing since the wasm-bindgen migration.

### Root causes

1. **`napi build`/`napi version` overwrites `browser.js`** — Reverts it from `./comprs-wasm.js` back to the WASI package. This happens during `changeset:version`.

2. **Vite 8 doesn't support ESM WASM imports** — `comprs-wasm.js` (wasm-pack bundler output) uses `import * as wasm from './comprs-wasm_bg.wasm'` which Vite rejects.

### Fixes

- **`scripts/patch-browser-js.js`** — Restores `browser.js` content after napi overwrites it. Called from `changeset:version` and `build:wasm-bindgen`.
- **`playground/wasm-loader.js`** — Manual WASM instantiation that bypasses ESM WASM imports (same pattern as rapid-fuzzy and our e2e tests).
- **Updated `playground/vite.config.js`** — Uses wasm-loader instead of browser-entry.js.
- **Removed Buffer polyfill** from playground main.js (wasm-bindgen doesn't need emnapi).

### Prevention (CLAUDE.md updated)

- Documented the `browser.js` overwrite issue and prevention mechanisms
- Updated directory structure to reflect three-crate architecture
- Added explicit rule: "run `node scripts/patch-browser-js.js` after any napi build/version"

Closes #332

## Checklist
- [x] All local checks pass (lint, typecheck, test, cargo test, clippy)
- [x] `browser.js` patch mechanism tested
- [x] CLAUDE.md updated with prevention documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ビルドプロセスの最適化とモジュール管理機能の改善を実施しました。
  * WebAssemblyモジュールの解決ロジックをアップデートし、開発環境の安定性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->