### PR TITLE
chore(deps): set minimumReleaseAge to 3 days in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:recommended"],
   "baseBranchPatterns": ["develop"],
   "schedule": ["at any time"],
+  "minimumReleaseAge": "3 days",
   "prConcurrentLimit": 0,
   "lockFileMaintenance": {
     "enabled": false


### PR DESCRIPTION
## Summary

- Add `minimumReleaseAge: "3 days"` to Renovate configuration to prevent adopting newly published packages that may be yanked or have undiscovered issues
- Applies globally to all dependency managers (npm, Cargo, GitHub Actions)

## Related issue

N/A — operational improvement

## Checklist

- [x] No code changes (`src/` or `crates/`) — changeset not required
- [x] Renovate config validated via schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 変更内容

* **Chores**
  * Renovate設定を更新しました。新しいリリースから依存関係更新PRの作成まで、最小3日間の期間が設定されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->