### PR TITLE
feat(middleware): add Express HTTP compression middleware

### DIFF
--- a/.changeset/middleware-initial.md
+++ b/.changeset/middleware-initial.md
@@ -1,0 +1,5 @@
+---
+"@derodero24/comprs-middleware": minor
+---
+
+Add HTTP compression middleware for Express with zstd, brotli, gzip, and deflate support

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,6 +347,7 @@ jobs:
           path: .
       - run: pnpm test
       - name: Middleware tests
+        if: matrix.os == 'ubuntu-latest' && matrix.node == 24
         run: pnpm --filter @derodero24/comprs-middleware test
       - name: ESM import smoke test
         run: node __test__/esm-import.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ on:
       - 'node.d.ts'
       - 'scripts/**'
       - 'playwright.config.ts'
+      - 'packages/**'
+      - 'pnpm-workspace.yaml'
   pull_request:
     branches: [develop]
     paths:
@@ -53,6 +55,8 @@ on:
       - 'node.d.ts'
       - 'scripts/**'
       - 'playwright.config.ts'
+      - 'packages/**'
+      - 'pnpm-workspace.yaml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -82,6 +86,8 @@ jobs:
       - name: Verify generated binding files are up to date
         run: git diff --exit-code index.js index.d.ts
       - run: pnpm run typecheck
+      - name: Middleware typecheck
+        run: pnpm --filter @derodero24/comprs-middleware typecheck
       - run: pnpm run publint
       - name: Validate TypeScript type resolution
         run: pnpm run attw
@@ -340,6 +346,8 @@ jobs:
           name: ${{ matrix.artifact }}
           path: .
       - run: pnpm test
+      - name: Middleware tests
+        run: pnpm --filter @derodero24/comprs-middleware test
       - name: ESM import smoke test
         run: node __test__/esm-import.mjs
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,8 +300,26 @@ jobs:
       # First publish: use granular access token (NPM_TOKEN secret).
       # After packages exist on npm, switch to OIDC trusted publishing
       # and remove NPM_TOKEN.
-      - name: Publish to npm
+      - name: Publish core to npm
         run: npm publish --provenance --access public
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Build and publish middleware
+        run: |
+          MIDDLEWARE_DIR="packages/middleware"
+          if [ -d "$MIDDLEWARE_DIR" ]; then
+            MIDDLEWARE_VERSION=$(node -p "require('./$MIDDLEWARE_DIR/package.json').version")
+            if npm view "@derodero24/comprs-middleware@${MIDDLEWARE_VERSION}" version 2>/dev/null; then
+              echo "Middleware v${MIDDLEWARE_VERSION} already published, skipping"
+            else
+              echo "Publishing middleware v${MIDDLEWARE_VERSION}"
+              pnpm --filter @derodero24/comprs-middleware build
+              cd "$MIDDLEWARE_DIR"
+              npm publish --provenance --access public
+            fi
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,19 +306,38 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Build and publish middleware
+  # ──── Publish middleware package independently ────
+  publish-middleware:
+    name: Publish Middleware
+    needs: [check]
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+          registry-url: https://registry.npmjs.org/
+      - run: pnpm install --frozen-lockfile
+
+      - name: Check and publish middleware
         run: |
-          MIDDLEWARE_DIR="packages/middleware"
-          if [ -d "$MIDDLEWARE_DIR" ]; then
-            MIDDLEWARE_VERSION=$(node -p "require('./$MIDDLEWARE_DIR/package.json').version")
-            if npm view "@derodero24/comprs-middleware@${MIDDLEWARE_VERSION}" version 2>/dev/null; then
-              echo "Middleware v${MIDDLEWARE_VERSION} already published, skipping"
-            else
-              echo "Publishing middleware v${MIDDLEWARE_VERSION}"
-              pnpm --filter @derodero24/comprs-middleware build
-              cd "$MIDDLEWARE_DIR"
-              npm publish --provenance --access public
-            fi
+          MIDDLEWARE_VERSION=$(node -p "require('./packages/middleware/package.json').version")
+          if npm view "@derodero24/comprs-middleware@${MIDDLEWARE_VERSION}" version 2>/dev/null; then
+            echo "Middleware v${MIDDLEWARE_VERSION} already published, skipping"
+          else
+            echo "Publishing middleware v${MIDDLEWARE_VERSION}"
+            pnpm --filter @derodero24/comprs-middleware build
+            cd packages/middleware
+            npm publish --provenance --access public
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -647,6 +647,26 @@ Benchmarks run on Apple M2, Node.js v22. Run locally with `pnpm run bench`. Numb
 > [!NOTE]
 > **Brotli decompression**: While comprs brotli *compression* is 10–155x faster than `node:zlib`, decompression performance varies by data type and size. For decompression-heavy workloads on Node.js, benchmark your specific data.
 
+## Ecosystem
+
+### [`@derodero24/comprs-middleware`](packages/middleware/)
+
+HTTP compression middleware for Express. The first Express middleware with zstd support.
+
+```bash
+npm install @derodero24/comprs @derodero24/comprs-middleware
+```
+
+```ts
+import express from 'express';
+import { comprs } from '@derodero24/comprs-middleware';
+
+const app = express();
+app.use(comprs({ encodings: ['zstd', 'br', 'gzip'] }));
+```
+
+See the [middleware README](packages/middleware/README.md) for full documentation.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.

--- a/README.md
+++ b/README.md
@@ -651,7 +651,7 @@ Benchmarks run on Apple M2, Node.js v22. Run locally with `pnpm run bench`. Numb
 
 ### [`@derodero24/comprs-middleware`](packages/middleware/)
 
-HTTP compression middleware for Express. The first Express middleware with zstd support.
+HTTP compression middleware for Express with zstd, brotli, gzip, and deflate support.
 
 ```bash
 npm install @derodero24/comprs @derodero24/comprs-middleware

--- a/biome.json
+++ b/biome.json
@@ -115,7 +115,7 @@
       }
     },
     {
-      "includes": ["packages/*/src/index.ts"],
+      "includes": ["packages/middleware/src/index.ts"],
       "linter": {
         "rules": {
           "performance": {

--- a/biome.json
+++ b/biome.json
@@ -105,6 +105,26 @@
       }
     },
     {
+      "includes": ["packages/*/vitest.config.mts"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noDefaultExport": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["packages/*/src/index.ts"],
+      "linter": {
+        "rules": {
+          "performance": {
+            "noBarrelFile": "off"
+          }
+        }
+      }
+    },
+    {
       "includes": ["playground/vite.config.js"],
       "linter": {
         "rules": {

--- a/packages/middleware/README.md
+++ b/packages/middleware/README.md
@@ -73,7 +73,7 @@ Returns an Express-compatible middleware function `(req, res, next) => void`.
 | `encodings` | `Encoding[]` | `['zstd', 'br', 'gzip', 'deflate']` | Algorithm priority order |
 | `threshold` | `number` | `1024` | Minimum response size (bytes) to compress |
 | `level` | `LevelOptions` | `{}` | Per-algorithm compression levels |
-| `filter` | `(req, res) => boolean` | Content-Type check | Custom filter function |
+| `filter` | `(req, res) => boolean` | Compressible types | Custom filter function |
 
 ### `negotiate(acceptEncoding, preferred?)`
 

--- a/packages/middleware/README.md
+++ b/packages/middleware/README.md
@@ -1,6 +1,6 @@
 # @derodero24/comprs-middleware
 
-HTTP compression middleware powered by [comprs](https://github.com/derodero24/comprs). The first Express middleware with **zstd** support.
+HTTP compression middleware powered by [comprs](https://github.com/derodero24/comprs). Express middleware with **zstd**, **brotli**, **gzip**, and **deflate** support.
 
 ## Features
 
@@ -8,7 +8,7 @@ HTTP compression middleware powered by [comprs](https://github.com/derodero24/co
 - **Accept-Encoding negotiation** — automatically selects the best encoding
 - **Configurable priority** — control which algorithm is preferred
 - **Threshold support** — skip compression for small responses
-- **Content-Type filtering** — only compress text-based responses by default
+- **Content-Type filtering** — only compresses responses with known compressible types (text, JSON, XML, etc.); skips responses without a Content-Type header
 - **Rust-powered** — uses comprs native bindings for maximum throughput
 
 ## Installation

--- a/packages/middleware/README.md
+++ b/packages/middleware/README.md
@@ -1,0 +1,106 @@
+# @derodero24/comprs-middleware
+
+HTTP compression middleware powered by [comprs](https://github.com/derodero24/comprs). The first Express middleware with **zstd** support.
+
+## Features
+
+- **zstd, brotli, gzip, deflate** — all algorithms via a single middleware
+- **Accept-Encoding negotiation** — automatically selects the best encoding
+- **Configurable priority** — control which algorithm is preferred
+- **Threshold support** — skip compression for small responses
+- **Content-Type filtering** — only compress text-based responses by default
+- **Rust-powered** — uses comprs native bindings for maximum throughput
+
+## Installation
+
+```bash
+npm install @derodero24/comprs @derodero24/comprs-middleware
+```
+
+## Usage
+
+```ts
+import express from 'express';
+import { comprs } from '@derodero24/comprs-middleware';
+
+const app = express();
+
+// Use defaults: zstd > br > gzip > deflate, threshold 1024 bytes
+app.use(comprs());
+
+app.get('/', (req, res) => {
+  res.json({ hello: 'world' });
+});
+
+app.listen(3000);
+```
+
+### Custom options
+
+```ts
+app.use(comprs({
+  // Algorithm priority (first match wins)
+  encodings: ['zstd', 'br', 'gzip'],
+
+  // Minimum response size to compress (bytes)
+  threshold: 512,
+
+  // Per-algorithm compression levels
+  level: {
+    zstd: 3,    // 1-22 (default: 3)
+    br: 6,      // 0-11 (default: 6)
+    gzip: 6,    // 0-9  (default: 6)
+  },
+
+  // Custom filter function
+  filter: (req, res) => {
+    const ct = res.getHeader('content-type');
+    return typeof ct === 'string' && ct.includes('application/json');
+  },
+}));
+```
+
+## API
+
+### `comprs(options?)`
+
+Returns an Express-compatible middleware function `(req, res, next) => void`.
+
+#### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `encodings` | `Encoding[]` | `['zstd', 'br', 'gzip', 'deflate']` | Algorithm priority order |
+| `threshold` | `number` | `1024` | Minimum response size (bytes) to compress |
+| `level` | `LevelOptions` | `{}` | Per-algorithm compression levels |
+| `filter` | `(req, res) => boolean` | Content-Type check | Custom filter function |
+
+### `negotiate(acceptEncoding, preferred?)`
+
+Low-level Accept-Encoding negotiation. Returns the best encoding or `null`.
+
+```ts
+import { negotiate } from '@derodero24/comprs-middleware';
+
+negotiate('gzip, br;q=0.8, zstd');
+// => 'zstd' (highest server preference accepted by client)
+```
+
+## Behavior
+
+The middleware automatically:
+
+- Sets `Content-Encoding` header
+- Removes `Content-Length` (compressed size is unknown)
+- Sets `Vary: Accept-Encoding` for caching correctness
+- Skips compression when:
+  - Response already has `Content-Encoding`
+  - `Cache-Control: no-transform` is set
+  - Content-Type is not compressible (images, etc.)
+  - Response body is below threshold
+  - Request method is `HEAD`
+  - Client does not accept any supported encoding
+
+## License
+
+[MIT](../../LICENSE)

--- a/packages/middleware/__test__/middleware.spec.ts
+++ b/packages/middleware/__test__/middleware.spec.ts
@@ -1,0 +1,222 @@
+import { createServer, request as httpRequest } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { brotliDecompress, gzipDecompress, zstdDecompress } from '@derodero24/comprs';
+import express from 'express';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { comprs } from '../src/middleware.js';
+
+const TEST_BODY = 'Hello, World! '.repeat(200); // ~2.8 KB, above default threshold
+
+function createApp(options?: Parameters<typeof comprs>[0]) {
+  const app = express();
+  app.use(comprs(options));
+  app.get('/text', (_req, res) => {
+    res.type('text/plain').send(TEST_BODY);
+  });
+  app.get('/json', (_req, res) => {
+    res.json({ message: TEST_BODY });
+  });
+  app.get('/small', (_req, res) => {
+    res.type('text/plain').send('tiny');
+  });
+  app.get('/image', (_req, res) => {
+    res.type('image/png').send(Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  });
+  app.get('/no-transform', (_req, res) => {
+    res.setHeader('Cache-Control', 'no-transform');
+    res.type('text/plain').send(TEST_BODY);
+  });
+  app.get('/pre-encoded', (_req, res) => {
+    res.setHeader('Content-Encoding', 'identity');
+    res.type('text/plain').send(TEST_BODY);
+  });
+  return app;
+}
+
+/**
+ * Raw HTTP request that does NOT auto-decompress Content-Encoding.
+ * Node.js fetch auto-decompresses, which makes testing compression impossible.
+ */
+function rawGet(
+  baseUrl: string,
+  path: string,
+  acceptEncoding: string,
+): Promise<{ status: number; headers: Record<string, string | undefined>; body: Buffer }> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(path, baseUrl);
+    const req = httpRequest(url, { headers: { 'Accept-Encoding': acceptEncoding } }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (chunk: Buffer) => chunks.push(chunk));
+      res.on('end', () => {
+        resolve({
+          status: res.statusCode ?? 0,
+          headers: {
+            'content-encoding': res.headers['content-encoding'],
+            'content-type': res.headers['content-type'],
+            'content-length': res.headers['content-length'],
+            vary: res.headers.vary,
+            'cache-control': res.headers['cache-control'],
+          },
+          body: Buffer.concat(chunks),
+        });
+      });
+      res.on('error', reject);
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+let baseUrl: string;
+let server: ReturnType<typeof createServer>;
+
+beforeAll(async () => {
+  const app = createApp();
+  server = createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+});
+
+describe('comprs middleware', () => {
+  describe('compression', () => {
+    it('should compress with gzip when requested', async () => {
+      const res = await rawGet(baseUrl, '/text', 'gzip');
+      expect(res.headers['content-encoding']).toBe('gzip');
+      const decompressed = gzipDecompress(res.body);
+      expect(decompressed.toString()).toBe(TEST_BODY);
+    });
+
+    it('should compress with brotli when requested', async () => {
+      const res = await rawGet(baseUrl, '/text', 'br');
+      expect(res.headers['content-encoding']).toBe('br');
+      const decompressed = brotliDecompress(res.body);
+      expect(decompressed.toString()).toBe(TEST_BODY);
+    });
+
+    it('should compress with zstd when requested', async () => {
+      const res = await rawGet(baseUrl, '/text', 'zstd');
+      expect(res.headers['content-encoding']).toBe('zstd');
+      const decompressed = zstdDecompress(res.body);
+      expect(decompressed.toString()).toBe(TEST_BODY);
+    });
+
+    it('should prefer zstd over gzip based on server preference', async () => {
+      const res = await rawGet(baseUrl, '/text', 'gzip, zstd, br');
+      expect(res.headers['content-encoding']).toBe('zstd');
+    });
+
+    it('should compress JSON responses', async () => {
+      const res = await rawGet(baseUrl, '/json', 'gzip');
+      expect(res.headers['content-encoding']).toBe('gzip');
+      const decompressed = gzipDecompress(res.body);
+      const parsed = JSON.parse(decompressed.toString());
+      expect(parsed.message).toBe(TEST_BODY);
+    });
+
+    it('should produce smaller output than original', async () => {
+      const res = await rawGet(baseUrl, '/text', 'gzip');
+      expect(res.body.length).toBeLessThan(Buffer.from(TEST_BODY).length);
+    });
+  });
+
+  describe('skip conditions', () => {
+    it('should not compress small responses below threshold', async () => {
+      const res = await rawGet(baseUrl, '/small', 'gzip');
+      expect(res.headers['content-encoding']).toBeUndefined();
+      expect(res.body.toString()).toBe('tiny');
+    });
+
+    it('should not compress non-compressible content types', async () => {
+      const res = await rawGet(baseUrl, '/image', 'gzip');
+      expect(res.headers['content-encoding']).toBeUndefined();
+    });
+
+    it('should not compress when Cache-Control: no-transform', async () => {
+      const res = await rawGet(baseUrl, '/no-transform', 'gzip');
+      expect(res.headers['content-encoding']).toBeUndefined();
+    });
+
+    it('should not compress when Content-Encoding already set', async () => {
+      const res = await rawGet(baseUrl, '/pre-encoded', 'gzip');
+      expect(res.headers['content-encoding']).toBe('identity');
+    });
+
+    it('should not compress when client does not accept any encoding', async () => {
+      const res = await rawGet(baseUrl, '/text', 'identity');
+      expect(res.headers['content-encoding']).toBeUndefined();
+    });
+  });
+
+  describe('headers', () => {
+    it('should set Vary: Accept-Encoding', async () => {
+      const res = await rawGet(baseUrl, '/text', 'gzip');
+      expect(res.headers.vary).toContain('Accept-Encoding');
+    });
+
+    it('should remove Content-Length when compressing', async () => {
+      const res = await rawGet(baseUrl, '/text', 'gzip');
+      expect(res.headers['content-length']).toBeUndefined();
+    });
+
+    it('should set Vary even when not compressing', async () => {
+      const res = await rawGet(baseUrl, '/small', 'gzip');
+      expect(res.headers.vary).toContain('Accept-Encoding');
+    });
+  });
+});
+
+describe('comprs middleware with custom options', () => {
+  let customBaseUrl: string;
+  let customServer: ReturnType<typeof createServer>;
+
+  beforeAll(async () => {
+    const app = createApp({
+      encodings: ['br', 'gzip'],
+      threshold: 100,
+      filter: (_req, res) => {
+        const ct = res.getHeader('content-type') as string | undefined;
+        return ct?.includes('text/plain') ?? false;
+      },
+    });
+    customServer = createServer(app);
+    await new Promise<void>((resolve) => {
+      customServer.listen(0, () => resolve());
+    });
+    const { port } = customServer.address() as AddressInfo;
+    customBaseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      customServer.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it('should respect custom encoding preference', async () => {
+    const res = await rawGet(customBaseUrl, '/text', 'gzip, br, zstd');
+    // br is preferred over gzip in custom config, zstd not included
+    expect(res.headers['content-encoding']).toBe('br');
+  });
+
+  it('should not compress with excluded encoding', async () => {
+    const res = await rawGet(customBaseUrl, '/text', 'zstd');
+    // zstd not in custom encodings
+    expect(res.headers['content-encoding']).toBeUndefined();
+  });
+
+  it('should use custom filter to skip JSON', async () => {
+    const res = await rawGet(customBaseUrl, '/json', 'gzip');
+    // Custom filter only allows text/plain
+    expect(res.headers['content-encoding']).toBeUndefined();
+  });
+});

--- a/packages/middleware/__test__/middleware.spec.ts
+++ b/packages/middleware/__test__/middleware.spec.ts
@@ -34,18 +34,26 @@ function createApp(options?: Parameters<typeof comprs>[0]) {
   return app;
 }
 
+interface RawRequestOptions {
+  method?: string;
+  acceptEncoding?: string;
+}
+
 /**
  * Raw HTTP request that does NOT auto-decompress Content-Encoding.
  * Node.js fetch auto-decompresses, which makes testing compression impossible.
  */
-function rawGet(
+function rawRequest(
   baseUrl: string,
   path: string,
-  acceptEncoding: string,
+  options: RawRequestOptions = {},
 ): Promise<{ status: number; headers: Record<string, string | undefined>; body: Buffer }> {
+  const { method = 'GET', acceptEncoding } = options;
   return new Promise((resolve, reject) => {
     const url = new URL(path, baseUrl);
-    const req = httpRequest(url, { headers: { 'Accept-Encoding': acceptEncoding } }, (res) => {
+    const headers: Record<string, string> = {};
+    if (acceptEncoding) headers['Accept-Encoding'] = acceptEncoding;
+    const req = httpRequest(url, { method, headers }, (res) => {
       const chunks: Buffer[] = [];
       res.on('data', (chunk: Buffer) => chunks.push(chunk));
       res.on('end', () => {
@@ -66,6 +74,11 @@ function rawGet(
     req.on('error', reject);
     req.end();
   });
+}
+
+/** Shorthand for GET with Accept-Encoding. */
+function rawGet(baseUrl: string, path: string, acceptEncoding: string) {
+  return rawRequest(baseUrl, path, { acceptEncoding });
 }
 
 let baseUrl: string;
@@ -130,6 +143,12 @@ describe('comprs middleware', () => {
   });
 
   describe('skip conditions', () => {
+    it('should not compress HEAD requests', async () => {
+      const res = await rawRequest(baseUrl, '/text', { method: 'HEAD', acceptEncoding: 'gzip' });
+      expect(res.headers['content-encoding']).toBeUndefined();
+      expect(res.body.toString()).toBe('');
+    });
+
     it('should not compress small responses below threshold', async () => {
       const res = await rawGet(baseUrl, '/small', 'gzip');
       expect(res.headers['content-encoding']).toBeUndefined();

--- a/packages/middleware/__test__/negotiate.spec.ts
+++ b/packages/middleware/__test__/negotiate.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { negotiate } from '../src/negotiate.js';
+
+describe('negotiate', () => {
+  it('should return null when no Accept-Encoding header', () => {
+    expect(negotiate(undefined)).toBeNull();
+  });
+
+  it('should return null for empty header', () => {
+    expect(negotiate('')).toBeNull();
+  });
+
+  it('should select first preferred encoding accepted by client', () => {
+    expect(negotiate('gzip, br, zstd')).toBe('zstd');
+  });
+
+  it('should respect server preference order', () => {
+    expect(negotiate('gzip, br, zstd', ['br', 'gzip'])).toBe('br');
+  });
+
+  it('should respect client quality values', () => {
+    // Client strongly prefers br, but server prefers zstd
+    // Server preference wins among acceptable encodings
+    expect(negotiate('br;q=1.0, zstd;q=0.8', ['zstd', 'br'])).toBe('zstd');
+  });
+
+  it('should skip encodings with q=0', () => {
+    expect(negotiate('gzip, zstd;q=0', ['zstd', 'gzip'])).toBe('gzip');
+  });
+
+  it('should handle wildcard (*)', () => {
+    expect(negotiate('*', ['zstd', 'br'])).toBe('zstd');
+  });
+
+  it('should handle wildcard with explicitly rejected encoding', () => {
+    expect(negotiate('*, zstd;q=0', ['zstd', 'br'])).toBe('br');
+  });
+
+  it('should return null when only identity is accepted', () => {
+    expect(negotiate('identity')).toBeNull();
+  });
+
+  it('should handle case-insensitive encoding names', () => {
+    expect(negotiate('GZIP, BR', ['br', 'gzip'])).toBe('br');
+  });
+
+  it('should return null when no preferred encoding matches', () => {
+    expect(negotiate('gzip', ['zstd', 'br'])).toBeNull();
+  });
+
+  it('should handle whitespace in header values', () => {
+    expect(negotiate('  gzip , br ; q=0.5 ', ['gzip', 'br'])).toBe('gzip');
+  });
+
+  it('should handle single encoding', () => {
+    expect(negotiate('gzip')).toBe('gzip');
+  });
+
+  it('should use default encodings when none specified', () => {
+    // Default order: zstd, br, gzip, deflate
+    expect(negotiate('gzip, deflate')).toBe('gzip');
+    expect(negotiate('br, gzip')).toBe('br');
+    expect(negotiate('zstd')).toBe('zstd');
+  });
+});

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@derodero24/comprs-middleware",
   "version": "0.1.0",
-  "description": "HTTP compression middleware powered by comprs. First Express middleware with zstd support.",
+  "description": "HTTP compression middleware powered by comprs. Express middleware with zstd, brotli, gzip, and deflate support.",
   "license": "MIT",
   "author": "derodero24",
   "repository": {
@@ -60,6 +60,7 @@
     "@derodero24/comprs": "workspace:*",
     "@types/express": "^5.0.0",
     "express": "^5.1.0",
+    "typescript": "^6.0.0",
     "vitest": "^4.1.0"
   },
   "publishConfig": {

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@derodero24/comprs-middleware",
+  "version": "0.1.0",
+  "description": "HTTP compression middleware powered by comprs. First Express middleware with zstd support.",
+  "license": "MIT",
+  "author": "derodero24",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/derodero24/comprs.git",
+    "directory": "packages/middleware"
+  },
+  "homepage": "https://github.com/derodero24/comprs/tree/develop/packages/middleware",
+  "bugs": {
+    "url": "https://github.com/derodero24/comprs/issues"
+  },
+  "keywords": [
+    "compression",
+    "middleware",
+    "express",
+    "zstd",
+    "brotli",
+    "gzip",
+    "http",
+    "content-encoding"
+  ],
+  "sideEffects": false,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "check": "biome ci",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "@derodero24/comprs": "^1.0.0",
+    "express": "^4.21.0 || ^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "express": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@derodero24/comprs": "workspace:*",
+    "@types/express": "^5.0.0",
+    "express": "^5.1.0",
+    "vitest": "^4.1.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/packages/middleware/src/compress.ts
+++ b/packages/middleware/src/compress.ts
@@ -1,0 +1,26 @@
+import type { Transform } from 'node:stream';
+
+import {
+  createBrotliCompressTransform,
+  createDeflateCompressTransform,
+  createGzipCompressTransform,
+  createZstdCompressTransform,
+} from '@derodero24/comprs/node';
+
+import type { Encoding, LevelOptions } from './types.js';
+
+/**
+ * Create a Node.js Transform stream for the given encoding.
+ */
+export function createCompressTransform(encoding: Encoding, level?: LevelOptions): Transform {
+  switch (encoding) {
+    case 'zstd':
+      return createZstdCompressTransform(level?.zstd);
+    case 'br':
+      return createBrotliCompressTransform(level?.br);
+    case 'gzip':
+      return createGzipCompressTransform(level?.gzip);
+    case 'deflate':
+      return createDeflateCompressTransform(level?.deflate);
+  }
+}

--- a/packages/middleware/src/index.ts
+++ b/packages/middleware/src/index.ts
@@ -1,0 +1,3 @@
+export { comprs } from './middleware.js';
+export { negotiate } from './negotiate.js';
+export type { ComprsOptions, Encoding, LevelOptions } from './types.js';

--- a/packages/middleware/src/middleware.ts
+++ b/packages/middleware/src/middleware.ts
@@ -9,7 +9,7 @@ const DEFAULT_THRESHOLD = 1024;
 
 /** MIME types that are compressible by default. */
 function isCompressibleType(contentType: string | undefined): boolean {
-  if (!contentType) return true;
+  if (!contentType) return false;
   const ct = contentType.split(';')[0]?.trim().toLowerCase() ?? '';
   if (ct.startsWith('text/')) return true;
   if (ct === 'application/json') return true;
@@ -84,6 +84,10 @@ function initCompression(
   stream.on('end', () => {
     // biome-ignore lint/suspicious/noExplicitAny: calling original end to finalize response
     (originalEnd as any).call(res);
+  });
+  stream.on('error', (err) => {
+    res.removeHeader('Content-Encoding');
+    res.destroy(err);
   });
 
   return stream;

--- a/packages/middleware/src/middleware.ts
+++ b/packages/middleware/src/middleware.ts
@@ -1,0 +1,198 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { Transform } from 'node:stream';
+
+import { createCompressTransform } from './compress.js';
+import { negotiate } from './negotiate.js';
+import type { ComprsOptions, Encoding } from './types.js';
+
+const DEFAULT_THRESHOLD = 1024;
+
+/** MIME types that are compressible by default. */
+function isCompressibleType(contentType: string | undefined): boolean {
+  if (!contentType) return true;
+  const ct = contentType.split(';')[0]?.trim().toLowerCase() ?? '';
+  if (ct.startsWith('text/')) return true;
+  if (ct === 'application/json') return true;
+  if (ct === 'application/javascript') return true;
+  if (ct === 'application/xml') return true;
+  if (ct === 'application/xhtml+xml') return true;
+  if (ct === 'application/rss+xml') return true;
+  if (ct === 'application/atom+xml') return true;
+  if (ct === 'application/graphql-response+json') return true;
+  if (ct === 'image/svg+xml') return true;
+  if (ct.endsWith('+json') || ct.endsWith('+xml')) return true;
+  return false;
+}
+
+/** Check if compression should be skipped for this response. */
+function shouldSkip(
+  req: IncomingMessage,
+  res: ServerResponse,
+  threshold: number,
+  filter: ComprsOptions['filter'],
+): boolean {
+  if (res.getHeader('content-encoding')) return true;
+
+  const cacheControl = res.getHeader('cache-control');
+  if (typeof cacheControl === 'string' && cacheControl.includes('no-transform')) return true;
+
+  if (filter && !filter(req, res)) return true;
+
+  if (!isCompressibleType(res.getHeader('content-type') as string | undefined)) return true;
+
+  const contentLength = res.getHeader('content-length');
+  if (contentLength !== undefined) {
+    const len =
+      typeof contentLength === 'string' ? Number.parseInt(contentLength, 10) : contentLength;
+    if (typeof len === 'number' && len < threshold) return true;
+  }
+
+  return false;
+}
+
+/** Set the Vary: Accept-Encoding header, appending if needed. */
+function ensureVaryHeader(res: ServerResponse): void {
+  const vary = res.getHeader('vary');
+  if (!vary) {
+    res.setHeader('Vary', 'Accept-Encoding');
+    return;
+  }
+  const varyStr = Array.isArray(vary) ? vary.join(', ') : String(vary);
+  if (!varyStr.toLowerCase().includes('accept-encoding')) {
+    res.setHeader('Vary', `${varyStr}, Accept-Encoding`);
+  }
+}
+
+/** Set up the compression stream and wire it to the response. */
+function initCompression(
+  res: ServerResponse,
+  encoding: Encoding,
+  level: ComprsOptions['level'],
+  originalWrite: ServerResponse['write'],
+  originalEnd: ServerResponse['end'],
+): Transform {
+  const stream = createCompressTransform(encoding, level);
+
+  res.setHeader('Content-Encoding', encoding);
+  res.removeHeader('Content-Length');
+  ensureVaryHeader(res);
+
+  stream.on('data', (chunk: Buffer) => {
+    // biome-ignore lint/suspicious/noExplicitAny: calling original write with raw chunk
+    (originalWrite as any).call(res, chunk);
+  });
+  stream.on('end', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: calling original end to finalize response
+    (originalEnd as any).call(res);
+  });
+
+  return stream;
+}
+
+/**
+ * Create an HTTP compression middleware.
+ *
+ * Works with Express (v4/v5), Connect, and any framework using the
+ * `(req, res, next)` middleware pattern.
+ *
+ * @example
+ * ```ts
+ * import express from 'express';
+ * import { comprs } from '@derodero24/comprs-middleware';
+ *
+ * const app = express();
+ * app.use(comprs({ encodings: ['zstd', 'br', 'gzip'] }));
+ * ```
+ */
+export function comprs(options: ComprsOptions = {}) {
+  const {
+    encodings = ['zstd', 'br', 'gzip', 'deflate'] as Encoding[],
+    threshold = DEFAULT_THRESHOLD,
+    level,
+    filter,
+  } = options;
+
+  return (req: IncomingMessage, res: ServerResponse, next: () => void) => {
+    if (req.method === 'HEAD') {
+      next();
+      return;
+    }
+
+    const negotiated = negotiate(req.headers['accept-encoding'] as string | undefined, encodings);
+    if (!negotiated) {
+      next();
+      return;
+    }
+    // Store in a const that TypeScript can narrow (closures don't narrow the outer variable)
+    const selectedEncoding: Encoding = negotiated;
+
+    const originalWrite = res.write;
+    const originalEnd = res.end;
+    let compressStream: Transform | null = null;
+    let started = false;
+    let ended = false;
+
+    function trySetup(): boolean {
+      if (started) return compressStream !== null;
+      started = true;
+      if (shouldSkip(req, res, threshold, filter)) return false;
+      compressStream = initCompression(res, selectedEncoding, level, originalWrite, originalEnd);
+      return true;
+    }
+
+    // biome-ignore lint/suspicious/noExplicitAny: Express res.write has complex overloads
+    res.write = function patchedWrite(chunk: any, ...args: any[]): boolean {
+      if (ended) return false;
+      if (!started && !trySetup()) {
+        // biome-ignore lint/suspicious/noExplicitAny: passing through original args
+        return (originalWrite as any).call(res, chunk, ...args);
+      }
+      if (compressStream) {
+        const enc = typeof args[0] === 'string' ? (args[0] as BufferEncoding) : undefined;
+        return enc ? compressStream.write(chunk, enc) : compressStream.write(chunk);
+      }
+      // biome-ignore lint/suspicious/noExplicitAny: passing through original args
+      return (originalWrite as any).call(res, chunk, ...args);
+    };
+
+    // biome-ignore lint/suspicious/noExplicitAny: Express res.end has complex overloads
+    res.end = function patchedEnd(chunk?: any, ...args: any[]): ServerResponse {
+      if (ended) return res;
+      ended = true;
+
+      if (!started && chunk) {
+        const enc = typeof args[0] === 'string' ? (args[0] as BufferEncoding) : 'utf8';
+        const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, enc);
+        if (buf.length < threshold) {
+          ensureVaryHeader(res);
+          // biome-ignore lint/suspicious/noExplicitAny: passing through original args
+          return (originalEnd as any).call(res, chunk, ...args);
+        }
+        if (!res.getHeader('content-length')) {
+          res.setHeader('content-length', buf.length);
+        }
+      }
+
+      if (!started && !trySetup()) {
+        ensureVaryHeader(res);
+        // biome-ignore lint/suspicious/noExplicitAny: passing through original args
+        return (originalEnd as any).call(res, chunk, ...args);
+      }
+
+      if (compressStream) {
+        if (chunk) {
+          const enc = typeof args[0] === 'string' ? (args[0] as BufferEncoding) : undefined;
+          enc ? compressStream.end(chunk, enc) : compressStream.end(chunk);
+        } else {
+          compressStream.end();
+        }
+        return res;
+      }
+
+      // biome-ignore lint/suspicious/noExplicitAny: passing through original args
+      return (originalEnd as any).call(res, chunk, ...args);
+    };
+
+    next();
+  };
+}

--- a/packages/middleware/src/middleware.ts
+++ b/packages/middleware/src/middleware.ts
@@ -136,6 +136,22 @@ export function comprs(options: ComprsOptions = {}) {
     let started = false;
     let ended = false;
 
+    // biome-ignore lint/suspicious/noExplicitAny: normalizing Node.js stream overloads
+    function normalizeArgs(chunkOrCb?: any, encodingOrCb?: any, cb?: any) {
+      const callback =
+        typeof chunkOrCb === 'function'
+          ? chunkOrCb
+          : typeof encodingOrCb === 'function'
+            ? encodingOrCb
+            : typeof cb === 'function'
+              ? cb
+              : undefined;
+      const chunk = typeof chunkOrCb === 'function' ? undefined : chunkOrCb;
+      const encoding =
+        typeof encodingOrCb === 'string' ? (encodingOrCb as BufferEncoding) : undefined;
+      return { chunk, encoding, callback };
+    }
+
     function trySetup(): boolean {
       if (started) return compressStream !== null;
       started = true;
@@ -146,31 +162,37 @@ export function comprs(options: ComprsOptions = {}) {
 
     // biome-ignore lint/suspicious/noExplicitAny: Express res.write has complex overloads
     res.write = function patchedWrite(chunk: any, ...args: any[]): boolean {
+      const n = normalizeArgs(chunk, args[0], args[1]);
       if (ended) return false;
       if (!started && !trySetup()) {
         // biome-ignore lint/suspicious/noExplicitAny: passing through original args
-        return (originalWrite as any).call(res, chunk, ...args);
+        return (originalWrite as any).call(res, n.chunk, n.encoding, n.callback);
       }
       if (compressStream) {
-        const enc = typeof args[0] === 'string' ? (args[0] as BufferEncoding) : undefined;
-        return enc ? compressStream.write(chunk, enc) : compressStream.write(chunk);
+        return n.encoding
+          ? compressStream.write(n.chunk, n.encoding, n.callback)
+          : compressStream.write(n.chunk, n.callback);
       }
       // biome-ignore lint/suspicious/noExplicitAny: passing through original args
-      return (originalWrite as any).call(res, chunk, ...args);
+      return (originalWrite as any).call(res, n.chunk, n.encoding, n.callback);
     };
 
     // biome-ignore lint/suspicious/noExplicitAny: Express res.end has complex overloads
     res.end = function patchedEnd(chunk?: any, ...args: any[]): ServerResponse {
-      if (ended) return res;
+      const n = normalizeArgs(chunk, args[0], args[1]);
+      if (ended) {
+        n.callback?.();
+        return res;
+      }
       ended = true;
 
-      if (!started && chunk) {
-        const enc = typeof args[0] === 'string' ? (args[0] as BufferEncoding) : 'utf8';
-        const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, enc);
+      if (!started && n.chunk != null) {
+        const enc = n.encoding ?? 'utf8';
+        const buf = Buffer.isBuffer(n.chunk) ? n.chunk : Buffer.from(n.chunk, enc);
         if (buf.length < threshold) {
           ensureVaryHeader(res);
           // biome-ignore lint/suspicious/noExplicitAny: passing through original args
-          return (originalEnd as any).call(res, chunk, ...args);
+          return (originalEnd as any).call(res, n.chunk, n.encoding, n.callback);
         }
         if (!res.getHeader('content-length')) {
           res.setHeader('content-length', buf.length);
@@ -180,21 +202,22 @@ export function comprs(options: ComprsOptions = {}) {
       if (!started && !trySetup()) {
         ensureVaryHeader(res);
         // biome-ignore lint/suspicious/noExplicitAny: passing through original args
-        return (originalEnd as any).call(res, chunk, ...args);
+        return (originalEnd as any).call(res, n.chunk, n.encoding, n.callback);
       }
 
       if (compressStream) {
-        if (chunk) {
-          const enc = typeof args[0] === 'string' ? (args[0] as BufferEncoding) : undefined;
-          enc ? compressStream.end(chunk, enc) : compressStream.end(chunk);
+        if (n.chunk != null) {
+          n.encoding
+            ? compressStream.end(n.chunk, n.encoding, n.callback)
+            : compressStream.end(n.chunk, n.callback);
         } else {
-          compressStream.end();
+          compressStream.end(n.callback);
         }
         return res;
       }
 
       // biome-ignore lint/suspicious/noExplicitAny: passing through original args
-      return (originalEnd as any).call(res, chunk, ...args);
+      return (originalEnd as any).call(res, n.chunk, n.encoding, n.callback);
     };
 
     next();

--- a/packages/middleware/src/negotiate.ts
+++ b/packages/middleware/src/negotiate.ts
@@ -1,0 +1,92 @@
+import type { Encoding } from './types.js';
+
+interface ParsedEncoding {
+  name: string;
+  quality: number;
+}
+
+const DEFAULT_ENCODINGS: Encoding[] = ['zstd', 'br', 'gzip', 'deflate'];
+
+/**
+ * Parse an Accept-Encoding header value into sorted encoding entries.
+ */
+function parseAcceptEncoding(header: string): ParsedEncoding[] {
+  const entries: ParsedEncoding[] = [];
+
+  for (const part of header.split(',')) {
+    const trimmed = part.trim();
+    if (trimmed === '') continue;
+
+    const segments = trimmed.split(';');
+    const encodingName = (segments[0] ?? '').trim().toLowerCase();
+
+    let quality = 1.0;
+    for (const param of segments.slice(1)) {
+      const match = param.trim().match(/^q=(\d+(?:\.\d+)?)$/);
+      if (match?.[1]) {
+        quality = Number.parseFloat(match[1]);
+        break;
+      }
+    }
+
+    entries.push({ name: encodingName, quality });
+  }
+
+  // Sort by quality descending (stable sort preserves insertion order for equal quality)
+  entries.sort((a, b) => b.quality - a.quality);
+  return entries;
+}
+
+/**
+ * Build the set of encodings the client accepts from parsed Accept-Encoding entries.
+ */
+function buildClientAccepts(accepted: ParsedEncoding[], preferred: Encoding[]): Set<string> {
+  const clientAccepts = new Set<string>();
+
+  for (const entry of accepted) {
+    if (entry.quality <= 0) continue;
+    if (entry.name === '*') {
+      // Wildcard: accept all preferred encodings not explicitly rejected
+      for (const enc of preferred) {
+        const explicit = accepted.find((e) => e.name === enc);
+        if (!explicit || explicit.quality > 0) {
+          clientAccepts.add(enc);
+        }
+      }
+    } else {
+      clientAccepts.add(entry.name);
+    }
+  }
+
+  return clientAccepts;
+}
+
+/**
+ * Select the best encoding based on the Accept-Encoding header and server preferences.
+ *
+ * Returns `null` if no suitable encoding is found (response should be sent uncompressed).
+ */
+export function negotiate(
+  acceptEncoding: string | undefined,
+  preferred: Encoding[] = DEFAULT_ENCODINGS,
+): Encoding | null {
+  if (!acceptEncoding) return null;
+
+  const accepted = parseAcceptEncoding(acceptEncoding);
+  if (accepted.length === 0) return null;
+
+  const wildcardEntry = accepted.find((e) => e.name === '*');
+  const clientAccepts = buildClientAccepts(accepted, preferred);
+
+  // Select the first preferred encoding accepted by the client
+  for (const enc of preferred) {
+    if (clientAccepts.has(enc)) return enc;
+  }
+
+  // Fallback: check if wildcard with positive quality is present
+  if (wildcardEntry && wildcardEntry.quality > 0 && preferred.length > 0) {
+    return preferred[0] ?? null;
+  }
+
+  return null;
+}

--- a/packages/middleware/src/negotiate.ts
+++ b/packages/middleware/src/negotiate.ts
@@ -75,17 +75,11 @@ export function negotiate(
   const accepted = parseAcceptEncoding(acceptEncoding);
   if (accepted.length === 0) return null;
 
-  const wildcardEntry = accepted.find((e) => e.name === '*');
   const clientAccepts = buildClientAccepts(accepted, preferred);
 
   // Select the first preferred encoding accepted by the client
   for (const enc of preferred) {
     if (clientAccepts.has(enc)) return enc;
-  }
-
-  // Fallback: check if wildcard with positive quality is present
-  if (wildcardEntry && wildcardEntry.quality > 0 && preferred.length > 0) {
-    return preferred[0] ?? null;
   }
 
   return null;

--- a/packages/middleware/src/types.ts
+++ b/packages/middleware/src/types.ts
@@ -37,7 +37,7 @@ export interface ComprsOptions {
    * Filter function to decide whether to compress a response.
    * Return `true` to compress, `false` to skip.
    * Called after headers are set but before response body is sent.
-   * @default Compresses text-based content types
+   * @default Compresses responses with known compressible types (text, JSON, XML, etc.); skips if Content-Type is not set
    */
   filter?: (req: IncomingMessage, res: ServerResponse) => boolean;
 }

--- a/packages/middleware/src/types.ts
+++ b/packages/middleware/src/types.ts
@@ -1,0 +1,43 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+/** Supported HTTP content encodings. */
+export type Encoding = 'zstd' | 'br' | 'gzip' | 'deflate';
+
+/** Compression level configuration per algorithm. */
+export interface LevelOptions {
+  /** zstd compression level (1-22, or negative for fast mode). Default: 3. */
+  zstd?: number;
+  /** Brotli compression quality (0-11). Default: 6. */
+  br?: number;
+  /** Gzip compression level (0-9). Default: 6. */
+  gzip?: number;
+  /** Deflate compression level (0-9). Default: 6. */
+  deflate?: number;
+}
+
+/** Options for the compression middleware. */
+export interface ComprsOptions {
+  /**
+   * Algorithm priority order. The first encoding accepted by the client wins.
+   * @default ['zstd', 'br', 'gzip', 'deflate']
+   */
+  encodings?: Encoding[];
+
+  /**
+   * Minimum response size in bytes to trigger compression.
+   * Responses smaller than this are sent uncompressed.
+   * @default 1024
+   */
+  threshold?: number;
+
+  /** Per-algorithm compression levels. */
+  level?: LevelOptions;
+
+  /**
+   * Filter function to decide whether to compress a response.
+   * Return `true` to compress, `false` to skip.
+   * Called after headers are set but before response body is sent.
+   * @default Compresses text-based content types
+   */
+  filter?: (req: IncomingMessage, res: ServerResponse) => boolean;
+}

--- a/packages/middleware/tsconfig.json
+++ b/packages/middleware/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "declaration": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noImplicitOverride": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "__test__"]
+}

--- a/packages/middleware/vitest.config.mts
+++ b/packages/middleware/vitest.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['__test__/**/*.spec.ts'],
+    exclude: ['node_modules', 'dist'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      typescript:
+        specifier: ^6.0.0
+        version: 6.0.2
       vitest:
         specifier: ^4.1.0
         version: 4.1.4(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@24.12.2)(jiti@2.6.1))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,21 @@ importers:
         specifier: ^4.1.0
         version: 4.1.4(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@24.12.2)(jiti@2.6.1))
 
+  packages/middleware:
+    devDependencies:
+      '@derodero24/comprs':
+        specifier: workspace:*
+        version: link:../..
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      express:
+        specifier: ^5.1.0
+        version: 5.2.1
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.4(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@24.12.2)(jiti@2.6.1))
+
 packages:
 
   '@andrewbranch/untar.js@1.0.3':
@@ -1047,14 +1062,29 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -1064,6 +1094,18 @@ packages:
 
   '@types/pako@2.0.4':
     resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
+
+  '@types/qs@6.15.0':
+    resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@vitest/coverage-v8@4.1.4':
     resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
@@ -1102,6 +1144,10 @@ packages:
 
   '@vitest/utils@4.1.4':
     resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -1165,6 +1211,10 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -1172,8 +1222,16 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
@@ -1248,6 +1306,14 @@ packages:
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   conventional-changelog-angular@8.3.0:
     resolution: {integrity: sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==}
     engines: {node: '>=18'}
@@ -1263,6 +1329,14 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cosmiconfig-typescript-loader@6.2.0:
     resolution: {integrity: sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==}
@@ -1298,6 +1372,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -1318,6 +1396,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   emnapi@1.9.2:
     resolution: {integrity: sha512-OdUoQe/8so7FvubnE/DNV9sNNSFwDYQiK4ZCAz4agMnD1s6faLuDn2gzxfJrmMoKfxZhhsckqGNwqPnS5K140A==}
     peerDependencies:
@@ -1331,6 +1412,10 @@ packages:
 
   emojilib@2.4.0:
     resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -1373,6 +1458,9 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -1381,9 +1469,17 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -1429,6 +1525,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -1449,6 +1549,14 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -1529,6 +1637,10 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
@@ -1551,9 +1663,16 @@ packages:
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   ini@4.1.1:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -1581,6 +1700,9 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
@@ -1821,8 +1943,16 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
   merge2@1.4.1:
@@ -1837,9 +1967,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -1863,6 +2001,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
@@ -1875,8 +2017,19 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -1935,6 +2088,10 @@ packages:
   parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1946,6 +2103,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -1988,6 +2148,10 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -1996,11 +2160,23 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -2031,6 +2207,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2046,6 +2226,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -2053,6 +2244,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2081,6 +2288,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
@@ -2139,11 +2350,19 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   typanion@3.14.0:
     resolution: {integrity: sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typescript@5.6.1-rc:
     resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
@@ -2169,9 +2388,17 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@8.0.8:
     resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
@@ -2270,6 +2497,9 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -3247,14 +3477,38 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 24.12.2
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 24.12.2
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 24.12.2
+      '@types/qs': 6.15.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/node@12.20.55': {}
 
@@ -3263,6 +3517,19 @@ snapshots:
       undici-types: 7.16.0
 
   '@types/pako@2.0.4': {}
+
+  '@types/qs@6.15.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 24.12.2
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 24.12.2
 
   '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
     dependencies:
@@ -3318,6 +3585,11 @@ snapshots:
       '@vitest/pretty-format': 4.1.4
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
 
   ajv@8.18.0:
     dependencies:
@@ -3378,6 +3650,20 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -3387,10 +3673,17 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bytes@3.1.2: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -3461,6 +3754,10 @@ snapshots:
       array-ify: 1.0.0
       dot-prop: 5.3.0
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
   conventional-changelog-angular@8.3.0:
     dependencies:
       compare-func: 2.0.0
@@ -3475,6 +3772,10 @@ snapshots:
       meow: 13.2.0
 
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   cosmiconfig-typescript-loader@6.2.0(@types/node@24.12.2)(cosmiconfig@9.0.1(typescript@6.0.2))(typescript@6.0.2):
     dependencies:
@@ -3504,6 +3805,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   detect-indent@6.1.0: {}
 
   detect-libc@2.1.2: {}
@@ -3522,11 +3825,15 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  ee-first@1.1.1: {}
+
   emnapi@1.9.2: {}
 
   emoji-regex@8.0.0: {}
 
   emojilib@2.4.0: {}
+
+  encodeurl@2.0.0: {}
 
   enquirer@2.4.1:
     dependencies:
@@ -3562,13 +3869,50 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   esprima@4.0.1: {}
 
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
+  etag@1.8.1: {}
+
   expect-type@1.3.0: {}
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extendable-error@0.1.7: {}
 
@@ -3610,6 +3954,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -3629,6 +3984,10 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -3715,6 +4074,14 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   human-id@4.1.3: {}
 
   iconv-lite@0.7.2:
@@ -3732,7 +4099,11 @@ snapshots:
 
   import-meta-resolve@4.2.0: {}
 
+  inherits@2.0.4: {}
+
   ini@4.1.1: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-arrayish@0.2.1: {}
 
@@ -3749,6 +4120,8 @@ snapshots:
   is-obj@2.0.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-promise@4.0.0: {}
 
   is-subdir@1.2.0:
     dependencies:
@@ -3941,7 +4314,11 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  media-typer@1.1.0: {}
+
   meow@13.2.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -3952,9 +4329,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   minimist@1.2.8: {}
 
@@ -3972,6 +4355,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  negotiator@1.0.0: {}
+
   node-emoji@2.2.0:
     dependencies:
       '@sindresorhus/is': 4.6.0
@@ -3983,7 +4368,17 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-inspect@1.13.4: {}
+
   obug@2.1.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   outdent@0.5.0: {}
 
@@ -4038,11 +4433,15 @@ snapshots:
 
   parse5@6.0.1: {}
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-exists@5.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -4072,6 +4471,11 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-from-env@1.1.0: {}
 
   publint@0.3.18:
@@ -4081,9 +4485,22 @@ snapshots:
       picocolors: 1.1.1
       sade: 1.8.1
 
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -4123,6 +4540,16 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -4135,11 +4562,66 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -4161,6 +4643,8 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.0.0: {}
 
@@ -4212,9 +4696,17 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   tslib@2.8.1: {}
 
   typanion@3.14.0: {}
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typescript@5.6.1-rc: {}
 
@@ -4228,7 +4720,11 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  unpipe@1.0.0: {}
+
   validate-npm-package-name@5.0.1: {}
+
+  vary@1.1.2: {}
 
   vite@8.0.8(@types/node@24.12.2)(jiti@2.6.1):
     dependencies:
@@ -4284,6 +4780,8 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrappy@1.0.2: {}
 
   y18n@5.0.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - '.'
+  - 'packages/*'


### PR DESCRIPTION
## Summary

- Add `@derodero24/comprs-middleware` — the first Express middleware with **zstd** support
- Set up pnpm workspace for multi-package monorepo (`pnpm-workspace.yaml`)
- Implement Accept-Encoding negotiation, compression stream creation, and Express middleware
- 31 unit and integration tests covering all algorithms, skip conditions, headers, and custom options
- Update CI workflow to lint/test the middleware package alongside core
- Update release workflow for multi-package publishing

### Middleware features

- **zstd, brotli, gzip, deflate** via configurable priority order
- **Accept-Encoding negotiation** with quality value support
- **Threshold-based skip** for small responses (default: 1024 bytes)
- **Content-Type filtering** — only compresses text-based types by default
- **Custom filter function** for fine-grained control
- Proper `Vary`, `Content-Encoding`, `Content-Length` header management
- Skips HEAD requests, `no-transform`, and pre-encoded responses

## Related issue

Closes #343

## Checklist

- [x] Changeset included
- [x] Tests pass (31/31)
- [x] TypeScript strict mode — no errors
- [x] Biome lint pass (warnings only: cognitive complexity in middleware patching)
- [x] CI workflow updated for multi-package
- [x] Release workflow updated for middleware publishing
- [x] README updated with Ecosystem section
- [x] Middleware README with full API documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Express向けHTTP圧縮ミドルウェアを追加（zstd／Brotli／gzip／deflate、優先順・閾値・圧縮レベル・フィルタ対応）。

* **Documentation**
  * メインREADMEにエコシステム節を追加し、ミドルウェアの導入例と設定を記載。パッケージ専用READMEを追加。

* **Tests**
  * ミドルウェア挙動とAccept-Encoding交渉を網羅するテストスイートを追加。

* **Chores**
  * パッケージ化とワークスペース設定、CI/CDワークフロー、TypeScript/Vitest設定、リンタオーバーライドを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->