### PR TITLE
feat(middleware): add Fastify and Hono support via subpath exports

### DIFF
--- a/.changeset/middleware-subpath.md
+++ b/.changeset/middleware-subpath.md
@@ -1,0 +1,11 @@
+---
+"@derodero24/comprs-middleware": minor
+---
+
+Restructure middleware to subpath exports with Fastify and Hono support
+
+- Add `@derodero24/comprs-middleware/express` subpath export
+- Add `@derodero24/comprs-middleware/fastify` Fastify plugin
+- Add `@derodero24/comprs-middleware/hono` Hono middleware
+- Extract shared logic (negotiate, compress, types) into framework-agnostic modules
+- Root export (`@derodero24/comprs-middleware`) now exports shared utilities only

--- a/README.md
+++ b/README.md
@@ -658,9 +658,17 @@ npm install @derodero24/comprs @derodero24/comprs-middleware
 ```
 
 ```ts
-import { comprs } from '@derodero24/comprs-middleware/express';  // Express
-import { comprs } from '@derodero24/comprs-middleware/fastify';  // Fastify
-import { comprs } from '@derodero24/comprs-middleware/hono';     // Hono
+// Express
+import { comprs } from '@derodero24/comprs-middleware/express';
+app.use(comprs());
+
+// Fastify
+import { comprs } from '@derodero24/comprs-middleware/fastify';
+app.register(comprs);
+
+// Hono
+import { comprs } from '@derodero24/comprs-middleware/hono';
+app.use(comprs());
 ```
 
 See the [middleware README](packages/middleware/README.md) for full documentation.

--- a/README.md
+++ b/README.md
@@ -651,18 +651,16 @@ Benchmarks run on Apple M2, Node.js v22. Run locally with `pnpm run bench`. Numb
 
 ### [`@derodero24/comprs-middleware`](packages/middleware/)
 
-HTTP compression middleware for Express with zstd, brotli, gzip, and deflate support.
+HTTP compression middleware for Express, Fastify, and Hono.
 
 ```bash
 npm install @derodero24/comprs @derodero24/comprs-middleware
 ```
 
 ```ts
-import express from 'express';
-import { comprs } from '@derodero24/comprs-middleware';
-
-const app = express();
-app.use(comprs({ encodings: ['zstd', 'br', 'gzip'] }));
+import { comprs } from '@derodero24/comprs-middleware/express';  // Express
+import { comprs } from '@derodero24/comprs-middleware/fastify';  // Fastify
+import { comprs } from '@derodero24/comprs-middleware/hono';     // Hono
 ```
 
 See the [middleware README](packages/middleware/README.md) for full documentation.

--- a/biome.json
+++ b/biome.json
@@ -115,6 +115,19 @@
       }
     },
     {
+      "includes": [
+        "packages/middleware/src/fastify.ts",
+        "packages/middleware/__test__/fastify.spec.ts"
+      ],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "useAwait": "off"
+          }
+        }
+      }
+    },
+    {
       "includes": ["packages/middleware/src/index.ts"],
       "linter": {
         "rules": {

--- a/packages/middleware/README.md
+++ b/packages/middleware/README.md
@@ -1,14 +1,15 @@
 # @derodero24/comprs-middleware
 
-HTTP compression middleware powered by [comprs](https://github.com/derodero24/comprs). Express middleware with **zstd**, **brotli**, **gzip**, and **deflate** support.
+HTTP compression middleware powered by [comprs](https://github.com/derodero24/comprs). Supports **Express**, **Fastify**, and **Hono** with **zstd**, **brotli**, **gzip**, and **deflate**.
 
 ## Features
 
-- **zstd, brotli, gzip, deflate** — all algorithms via a single middleware
+- **Multi-framework** — Express, Fastify, and Hono via subpath imports
+- **zstd, brotli, gzip, deflate** — all algorithms via a single package
 - **Accept-Encoding negotiation** — automatically selects the best encoding
 - **Configurable priority** — control which algorithm is preferred
 - **Threshold support** — skip compression for small responses
-- **Content-Type filtering** — only compresses responses with known compressible types (text, JSON, XML, etc.); skips responses without a Content-Type header
+- **Content-Type filtering** — only compresses known compressible types; skips responses without a Content-Type header
 - **Rust-powered** — uses comprs native bindings for maximum throughput
 
 ## Installation
@@ -19,61 +20,70 @@ npm install @derodero24/comprs @derodero24/comprs-middleware
 
 ## Usage
 
+### Express
+
 ```ts
 import express from 'express';
-import { comprs } from '@derodero24/comprs-middleware';
+import { comprs } from '@derodero24/comprs-middleware/express';
 
 const app = express();
-
-// Use defaults: zstd > br > gzip > deflate, threshold 1024 bytes
 app.use(comprs());
-
-app.get('/', (req, res) => {
-  res.json({ hello: 'world' });
-});
-
-app.listen(3000);
 ```
 
-### Custom options
+### Fastify
 
 ```ts
-app.use(comprs({
-  // Algorithm priority (first match wins)
-  encodings: ['zstd', 'br', 'gzip'],
+import Fastify from 'fastify';
+import { comprs } from '@derodero24/comprs-middleware/fastify';
 
-  // Minimum response size to compress (bytes)
-  threshold: 512,
+const app = Fastify();
+app.register(comprs);
+```
 
-  // Per-algorithm compression levels
-  level: {
-    zstd: 3,    // 1-22 (default: 3)
-    br: 6,      // 0-11 (default: 6)
-    gzip: 6,    // 0-9  (default: 6)
-  },
+### Hono
 
-  // Custom filter function
-  filter: (req, res) => {
-    const ct = res.getHeader('content-type');
-    return typeof ct === 'string' && ct.includes('application/json');
-  },
-}));
+```ts
+import { Hono } from 'hono';
+import { comprs } from '@derodero24/comprs-middleware/hono';
+
+const app = new Hono();
+app.use(comprs());
+```
+
+### Options
+
+All adapters accept the same core options:
+
+```ts
+comprs({
+  encodings: ['zstd', 'br', 'gzip'],   // Algorithm priority
+  threshold: 512,                        // Min response size (bytes)
+  level: { zstd: 3, br: 6, gzip: 6 },  // Per-algorithm levels
+  filter: (req, res) => true,            // Custom filter (Express/Fastify)
+})
 ```
 
 ## API
 
-### `comprs(options?)`
+### Subpath exports
 
-Returns an Express-compatible middleware function `(req, res, next) => void`.
+| Import path | Framework | Returns |
+|-------------|-----------|---------|
+| `@derodero24/comprs-middleware/express` | Express/Connect | `(req, res, next) => void` |
+| `@derodero24/comprs-middleware/fastify` | Fastify | `FastifyPluginAsync` |
+| `@derodero24/comprs-middleware/hono` | Hono | `MiddlewareHandler` |
+| `@derodero24/comprs-middleware` | — | `negotiate()`, types |
 
-#### Options
+### Option reference
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `encodings` | `Encoding[]` | `['zstd', 'br', 'gzip', 'deflate']` | Algorithm priority order |
 | `threshold` | `number` | `1024` | Minimum response size (bytes) to compress |
 | `level` | `LevelOptions` | `{}` | Per-algorithm compression levels |
-| `filter` | `(req, res) => boolean` | Compressible types | Custom filter function |
+| `filter` | `(req, res) => boolean` | Compressible types | Custom filter (Express/Fastify) |
+
+> Hono adapter accepts `filter: (c: Context) => boolean` instead.
 
 ### `negotiate(acceptEncoding, preferred?)`
 
@@ -88,15 +98,16 @@ negotiate('gzip, br;q=0.8, zstd');
 
 ## Behavior
 
-The middleware automatically:
+All adapters automatically:
 
-- Sets `Content-Encoding` header
-- Removes `Content-Length` (compressed size is unknown)
-- Sets `Vary: Accept-Encoding` for caching correctness
-- Skips compression when:
+- Set `Content-Encoding` header
+- Remove `Content-Length` (compressed size is unknown)
+- Set `Vary: Accept-Encoding` for caching correctness
+- Skip compression when:
   - Response already has `Content-Encoding`
   - `Cache-Control: no-transform` is set
   - Content-Type is not compressible (images, etc.)
+  - Content-Type is not set
   - Response body is below threshold
   - Request method is `HEAD`
   - Client does not accept any supported encoding

--- a/packages/middleware/__test__/fastify.spec.ts
+++ b/packages/middleware/__test__/fastify.spec.ts
@@ -130,6 +130,12 @@ describe('comprs fastify plugin', () => {
       const res = await rawGet(baseUrl, '/no-transform', 'gzip');
       expect(res.headers['content-encoding']).toBeUndefined();
     });
+
+    it('should not compress when client only accepts identity', async () => {
+      const res = await rawGet(baseUrl, '/text', 'identity');
+      expect(res.headers['content-encoding']).toBeUndefined();
+      expect(res.body.toString()).toBe(TEST_BODY);
+    });
   });
 
   describe('headers', () => {

--- a/packages/middleware/__test__/fastify.spec.ts
+++ b/packages/middleware/__test__/fastify.spec.ts
@@ -1,0 +1,146 @@
+import { request as httpRequest } from 'node:http';
+import { brotliDecompress, gzipDecompress, zstdDecompress } from '@derodero24/comprs';
+import type { FastifyInstance } from 'fastify';
+import Fastify from 'fastify';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { comprs } from '../src/fastify.js';
+
+const TEST_BODY = 'Hello, World! '.repeat(200);
+
+function rawGet(
+  baseUrl: string,
+  path: string,
+  acceptEncoding: string,
+): Promise<{ status: number; headers: Record<string, string | undefined>; body: Buffer }> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(path, baseUrl);
+    const req = httpRequest(url, { headers: { 'Accept-Encoding': acceptEncoding } }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (chunk: Buffer) => chunks.push(chunk));
+      res.on('end', () => {
+        resolve({
+          status: res.statusCode ?? 0,
+          headers: {
+            'content-encoding': res.headers['content-encoding'],
+            'content-type': res.headers['content-type'],
+            'content-length': res.headers['content-length'],
+            vary: res.headers.vary,
+          },
+          body: Buffer.concat(chunks),
+        });
+      });
+      res.on('error', reject);
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+let app: FastifyInstance;
+let baseUrl: string;
+
+beforeAll(async () => {
+  app = Fastify();
+  await app.register(comprs);
+
+  app.get('/text', async (_request, reply) => {
+    reply.type('text/plain');
+    return TEST_BODY;
+  });
+
+  app.get('/json', async () => {
+    return { message: TEST_BODY };
+  });
+
+  app.get('/small', async (_request, reply) => {
+    reply.type('text/plain');
+    return 'tiny';
+  });
+
+  app.get('/image', async (_request, reply) => {
+    reply.type('image/png');
+    return Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+  });
+
+  app.get('/no-transform', async (_request, reply) => {
+    reply.header('Cache-Control', 'no-transform');
+    reply.type('text/plain');
+    return TEST_BODY;
+  });
+
+  await app.listen({ port: 0, host: '127.0.0.1' });
+  const addr = app.addresses()[0];
+  baseUrl = `http://127.0.0.1:${addr?.port}`;
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe('comprs fastify plugin', () => {
+  describe('compression', () => {
+    it('should compress with gzip', async () => {
+      const res = await rawGet(baseUrl, '/text', 'gzip');
+      expect(res.headers['content-encoding']).toBe('gzip');
+      const decompressed = gzipDecompress(res.body);
+      expect(decompressed.toString()).toBe(TEST_BODY);
+    });
+
+    it('should compress with brotli', async () => {
+      const res = await rawGet(baseUrl, '/text', 'br');
+      expect(res.headers['content-encoding']).toBe('br');
+      const decompressed = brotliDecompress(res.body);
+      expect(decompressed.toString()).toBe(TEST_BODY);
+    });
+
+    it('should compress with zstd', async () => {
+      const res = await rawGet(baseUrl, '/text', 'zstd');
+      expect(res.headers['content-encoding']).toBe('zstd');
+      const decompressed = zstdDecompress(res.body);
+      expect(decompressed.toString()).toBe(TEST_BODY);
+    });
+
+    it('should prefer zstd based on server preference', async () => {
+      const res = await rawGet(baseUrl, '/text', 'gzip, zstd, br');
+      expect(res.headers['content-encoding']).toBe('zstd');
+    });
+
+    it('should compress JSON responses', async () => {
+      const res = await rawGet(baseUrl, '/json', 'gzip');
+      expect(res.headers['content-encoding']).toBe('gzip');
+      const decompressed = gzipDecompress(res.body);
+      const parsed = JSON.parse(decompressed.toString());
+      expect(parsed.message).toBe(TEST_BODY);
+    });
+  });
+
+  describe('skip conditions', () => {
+    it('should not compress small responses', async () => {
+      const res = await rawGet(baseUrl, '/small', 'gzip');
+      expect(res.headers['content-encoding']).toBeUndefined();
+    });
+
+    it('should not compress non-compressible types', async () => {
+      const res = await rawGet(baseUrl, '/image', 'gzip');
+      expect(res.headers['content-encoding']).toBeUndefined();
+    });
+
+    it('should not compress when no-transform', async () => {
+      const res = await rawGet(baseUrl, '/no-transform', 'gzip');
+      expect(res.headers['content-encoding']).toBeUndefined();
+    });
+  });
+
+  describe('headers', () => {
+    it('should set Vary: Accept-Encoding', async () => {
+      const res = await rawGet(baseUrl, '/text', 'gzip');
+      expect(res.headers.vary).toContain('Accept-Encoding');
+    });
+
+    it('should remove Content-Length when compressing', async () => {
+      const res = await rawGet(baseUrl, '/text', 'gzip');
+      expect(res.headers['content-length']).toBeUndefined();
+    });
+  });
+});

--- a/packages/middleware/__test__/hono.spec.ts
+++ b/packages/middleware/__test__/hono.spec.ts
@@ -1,0 +1,116 @@
+import { brotliDecompress, gzipDecompress, zstdDecompress } from '@derodero24/comprs';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+
+import { comprs } from '../src/hono.js';
+
+const TEST_BODY = 'Hello, World! '.repeat(200);
+
+function createApp(options?: Parameters<typeof comprs>[0]) {
+  const app = new Hono();
+  app.use(comprs(options));
+
+  app.get('/text', (c) => c.text(TEST_BODY));
+  app.get('/json', (c) => c.json({ message: TEST_BODY }));
+  app.get('/small', (c) => c.text('tiny'));
+  app.get('/image', (c) => {
+    return c.body(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+      headers: { 'Content-Type': 'image/png' },
+    });
+  });
+  app.get('/no-transform', (c) => {
+    c.header('Cache-Control', 'no-transform');
+    return c.text(TEST_BODY);
+  });
+
+  return app;
+}
+
+async function rawGet(app: Hono, path: string, acceptEncoding: string) {
+  const res = await app.request(path, {
+    headers: { 'Accept-Encoding': acceptEncoding },
+  });
+  return {
+    status: res.status,
+    headers: {
+      'content-encoding': res.headers.get('content-encoding') ?? undefined,
+      'content-type': res.headers.get('content-type') ?? undefined,
+      vary: res.headers.get('vary') ?? undefined,
+    },
+    body: Buffer.from(await res.arrayBuffer()),
+  };
+}
+
+describe('comprs hono middleware', () => {
+  const app = createApp();
+
+  describe('compression', () => {
+    it('should compress with gzip', async () => {
+      const res = await rawGet(app, '/text', 'gzip');
+      expect(res.headers['content-encoding']).toBe('gzip');
+      const decompressed = gzipDecompress(res.body);
+      expect(decompressed.toString()).toBe(TEST_BODY);
+    });
+
+    it('should compress with brotli', async () => {
+      const res = await rawGet(app, '/text', 'br');
+      expect(res.headers['content-encoding']).toBe('br');
+      const decompressed = brotliDecompress(res.body);
+      expect(decompressed.toString()).toBe(TEST_BODY);
+    });
+
+    it('should compress with zstd', async () => {
+      const res = await rawGet(app, '/text', 'zstd');
+      expect(res.headers['content-encoding']).toBe('zstd');
+      const decompressed = zstdDecompress(res.body);
+      expect(decompressed.toString()).toBe(TEST_BODY);
+    });
+
+    it('should prefer zstd based on server preference', async () => {
+      const res = await rawGet(app, '/text', 'gzip, zstd, br');
+      expect(res.headers['content-encoding']).toBe('zstd');
+    });
+
+    it('should compress JSON responses', async () => {
+      const res = await rawGet(app, '/json', 'gzip');
+      expect(res.headers['content-encoding']).toBe('gzip');
+      const decompressed = gzipDecompress(res.body);
+      const parsed = JSON.parse(decompressed.toString());
+      expect(parsed.message).toBe(TEST_BODY);
+    });
+  });
+
+  describe('skip conditions', () => {
+    it('should not compress small responses', async () => {
+      const res = await rawGet(app, '/small', 'gzip');
+      expect(res.headers['content-encoding']).toBeUndefined();
+    });
+
+    it('should not compress non-compressible types', async () => {
+      const res = await rawGet(app, '/image', 'gzip');
+      expect(res.headers['content-encoding']).toBeUndefined();
+    });
+
+    it('should not compress when no-transform', async () => {
+      const res = await rawGet(app, '/no-transform', 'gzip');
+      expect(res.headers['content-encoding']).toBeUndefined();
+    });
+
+    it('should not compress when client rejects all', async () => {
+      const res = await rawGet(app, '/text', 'identity');
+      expect(res.headers['content-encoding']).toBeUndefined();
+    });
+  });
+
+  describe('headers', () => {
+    it('should set Vary: Accept-Encoding', async () => {
+      const res = await rawGet(app, '/text', 'gzip');
+      expect(res.headers.vary).toContain('Accept-Encoding');
+    });
+
+    it('should set Vary even when not compressing', async () => {
+      const res = await rawGet(app, '/small', 'gzip');
+      expect(res.headers.vary).toContain('Accept-Encoding');
+    });
+  });
+});

--- a/packages/middleware/__test__/middleware.spec.ts
+++ b/packages/middleware/__test__/middleware.spec.ts
@@ -4,7 +4,7 @@ import { brotliDecompress, gzipDecompress, zstdDecompress } from '@derodero24/co
 import express from 'express';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { comprs } from '../src/middleware.js';
+import { comprs } from '../src/express.js';
 
 const TEST_BODY = 'Hello, World! '.repeat(200); // ~2.8 KB, above default threshold
 

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@derodero24/comprs-middleware",
   "version": "0.2.0",
-  "description": "HTTP compression middleware powered by comprs. Express middleware with zstd, brotli, gzip, and deflate support.",
+  "description": "HTTP compression middleware powered by comprs. Supports Express, Fastify, and Hono with zstd, brotli, gzip, and deflate.",
   "license": "MIT",
   "author": "derodero24",
   "repository": {
@@ -17,6 +17,8 @@
     "compression",
     "middleware",
     "express",
+    "fastify",
+    "hono",
     "zstd",
     "brotli",
     "gzip",
@@ -32,6 +34,24 @@
       "import": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
+      }
+    },
+    "./express": {
+      "import": {
+        "types": "./dist/express.d.ts",
+        "default": "./dist/express.js"
+      }
+    },
+    "./fastify": {
+      "import": {
+        "types": "./dist/fastify.d.ts",
+        "default": "./dist/fastify.js"
+      }
+    },
+    "./hono": {
+      "import": {
+        "types": "./dist/hono.d.ts",
+        "default": "./dist/hono.js"
       }
     }
   },
@@ -49,10 +69,18 @@
   },
   "peerDependencies": {
     "@derodero24/comprs": "^1.0.0",
-    "express": "^4.21.0 || ^5.0.0"
+    "express": "^4.21.0 || ^5.0.0",
+    "fastify": "^5.0.0",
+    "hono": "^4.0.0"
   },
   "peerDependenciesMeta": {
     "express": {
+      "optional": true
+    },
+    "fastify": {
+      "optional": true
+    },
+    "hono": {
       "optional": true
     }
   },
@@ -60,6 +88,8 @@
     "@derodero24/comprs": "workspace:*",
     "@types/express": "^5.0.0",
     "express": "^5.1.0",
+    "fastify": "^5.0.0",
+    "hono": "^4.0.0",
     "typescript": "^6.0.0",
     "vitest": "^4.1.0"
   },

--- a/packages/middleware/src/express.ts
+++ b/packages/middleware/src/express.ts
@@ -3,26 +3,8 @@ import type { Transform } from 'node:stream';
 
 import { createCompressTransform } from './compress.js';
 import { negotiate } from './negotiate.js';
+import { appendVary, DEFAULT_ENCODINGS, DEFAULT_THRESHOLD, isCompressibleType } from './shared.js';
 import type { ComprsOptions, Encoding } from './types.js';
-
-const DEFAULT_THRESHOLD = 1024;
-
-/** MIME types that are compressible by default. */
-function isCompressibleType(contentType: string | undefined): boolean {
-  if (!contentType) return false;
-  const ct = contentType.split(';')[0]?.trim().toLowerCase() ?? '';
-  if (ct.startsWith('text/')) return true;
-  if (ct === 'application/json') return true;
-  if (ct === 'application/javascript') return true;
-  if (ct === 'application/xml') return true;
-  if (ct === 'application/xhtml+xml') return true;
-  if (ct === 'application/rss+xml') return true;
-  if (ct === 'application/atom+xml') return true;
-  if (ct === 'application/graphql-response+json') return true;
-  if (ct === 'image/svg+xml') return true;
-  if (ct.endsWith('+json') || ct.endsWith('+xml')) return true;
-  return false;
-}
 
 /** Check if compression should be skipped for this response. */
 function shouldSkip(
@@ -50,17 +32,10 @@ function shouldSkip(
   return false;
 }
 
-/** Set the Vary: Accept-Encoding header, appending if needed. */
 function ensureVaryHeader(res: ServerResponse): void {
   const vary = res.getHeader('vary');
-  if (!vary) {
-    res.setHeader('Vary', 'Accept-Encoding');
-    return;
-  }
-  const varyStr = Array.isArray(vary) ? vary.join(', ') : String(vary);
-  if (!varyStr.toLowerCase().includes('accept-encoding')) {
-    res.setHeader('Vary', `${varyStr}, Accept-Encoding`);
-  }
+  const varyStr = Array.isArray(vary) ? vary.join(', ') : (vary as string | undefined);
+  res.setHeader('Vary', appendVary(varyStr));
 }
 
 /** Set up the compression stream and wire it to the response. */
@@ -94,15 +69,12 @@ function initCompression(
 }
 
 /**
- * Create an HTTP compression middleware.
- *
- * Works with Express (v4/v5), Connect, and any framework using the
- * `(req, res, next)` middleware pattern.
+ * Create an Express/Connect HTTP compression middleware.
  *
  * @example
  * ```ts
  * import express from 'express';
- * import { comprs } from '@derodero24/comprs-middleware';
+ * import { comprs } from '@derodero24/comprs-middleware/express';
  *
  * const app = express();
  * app.use(comprs({ encodings: ['zstd', 'br', 'gzip'] }));
@@ -110,7 +82,7 @@ function initCompression(
  */
 export function comprs(options: ComprsOptions = {}) {
   const {
-    encodings = ['zstd', 'br', 'gzip', 'deflate'] as Encoding[],
+    encodings = [...DEFAULT_ENCODINGS] as Encoding[],
     threshold = DEFAULT_THRESHOLD,
     level,
     filter,
@@ -127,7 +99,6 @@ export function comprs(options: ComprsOptions = {}) {
       next();
       return;
     }
-    // Store in a const that TypeScript can narrow (closures don't narrow the outer variable)
     const selectedEncoding: Encoding = negotiated;
 
     const originalWrite = res.write;

--- a/packages/middleware/src/express.ts
+++ b/packages/middleware/src/express.ts
@@ -16,7 +16,8 @@ function shouldSkip(
   if (res.getHeader('content-encoding')) return true;
 
   const cacheControl = res.getHeader('cache-control');
-  if (typeof cacheControl === 'string' && cacheControl.includes('no-transform')) return true;
+  if (typeof cacheControl === 'string' && cacheControl.toLowerCase().includes('no-transform'))
+    return true;
 
   if (filter && !filter(req, res)) return true;
 

--- a/packages/middleware/src/fastify.ts
+++ b/packages/middleware/src/fastify.ts
@@ -62,12 +62,18 @@ const plugin: FastifyPluginAsync<ComprsOptions> = async (fastify, options) => {
     if (!encoding) return payload;
     if (shouldSkipHeaders(reply, filter, request)) return payload;
 
-    // Handle stream payloads
+    // Stream payloads: compress on the fly without threshold check (size is unknown).
+    // Content-Length is removed since compressed size differs from original.
     if (payload instanceof Readable) {
       const stream = createCompressTransform(encoding, level);
       reply.header('Content-Encoding', encoding);
       reply.removeHeader('Content-Length');
-      pipeline(payload, stream).catch(() => {});
+      pipeline(payload, stream).catch((err: NodeJS.ErrnoException) => {
+        // Premature close is expected when clients disconnect mid-stream
+        if (err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
+          fastify.log.debug(err, 'comprs: compression pipeline error');
+        }
+      });
       return stream;
     }
 

--- a/packages/middleware/src/fastify.ts
+++ b/packages/middleware/src/fastify.ts
@@ -16,7 +16,7 @@ function shouldSkipHeaders(
   if (reply.getHeader('content-encoding')) return true;
 
   const cacheControl = reply.getHeader('cache-control') as string | undefined;
-  if (cacheControl?.includes('no-transform')) return true;
+  if (cacheControl?.toLowerCase().includes('no-transform')) return true;
 
   if (filter && !filter(request.raw, reply.raw)) return true;
 

--- a/packages/middleware/src/fastify.ts
+++ b/packages/middleware/src/fastify.ts
@@ -1,0 +1,96 @@
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
+
+import { createCompressTransform } from './compress.js';
+import { negotiate } from './negotiate.js';
+import { appendVary, DEFAULT_ENCODINGS, DEFAULT_THRESHOLD, isCompressibleType } from './shared.js';
+import type { ComprsOptions, Encoding } from './types.js';
+
+function shouldSkipHeaders(
+  reply: FastifyReply,
+  filter: ComprsOptions['filter'],
+  request: FastifyRequest,
+): boolean {
+  if (reply.getHeader('content-encoding')) return true;
+
+  const cacheControl = reply.getHeader('cache-control') as string | undefined;
+  if (cacheControl?.includes('no-transform')) return true;
+
+  if (filter && !filter(request.raw, reply.raw)) return true;
+
+  if (!isCompressibleType(reply.getHeader('content-type') as string | undefined)) return true;
+
+  return false;
+}
+
+function payloadToBuffer(payload: unknown): Buffer | null {
+  if (typeof payload === 'string') return Buffer.from(payload);
+  if (Buffer.isBuffer(payload)) return payload;
+  return null;
+}
+
+/**
+ * Fastify compression plugin.
+ *
+ * @example
+ * ```ts
+ * import Fastify from 'fastify';
+ * import { comprs } from '@derodero24/comprs-middleware/fastify';
+ *
+ * const app = Fastify();
+ * app.register(comprs, { encodings: ['zstd', 'br', 'gzip'] });
+ * ```
+ */
+const plugin: FastifyPluginAsync<ComprsOptions> = async (fastify, options) => {
+  const {
+    encodings = [...DEFAULT_ENCODINGS] as Encoding[],
+    threshold = DEFAULT_THRESHOLD,
+    level,
+    filter,
+  } = options;
+
+  fastify.addHook('onSend', async (request, reply, payload) => {
+    if (request.method === 'HEAD') return payload;
+
+    const encoding = negotiate(request.headers['accept-encoding'], encodings);
+
+    // Always set Vary
+    reply.header('Vary', appendVary(reply.getHeader('vary') as string | undefined));
+
+    if (!encoding) return payload;
+    if (shouldSkipHeaders(reply, filter, request)) return payload;
+
+    // Handle stream payloads
+    if (payload instanceof Readable) {
+      const stream = createCompressTransform(encoding, level);
+      reply.header('Content-Encoding', encoding);
+      reply.removeHeader('Content-Length');
+      pipeline(payload, stream).catch(() => {});
+      return stream;
+    }
+
+    // Handle string/Buffer payloads
+    const buf = payloadToBuffer(payload);
+    if (!buf) return payload;
+    if (buf.length < threshold) return payload;
+
+    const stream = createCompressTransform(encoding, level);
+    reply.header('Content-Encoding', encoding);
+    reply.removeHeader('Content-Length');
+
+    // Write data on next tick so Fastify has time to set up piping
+    process.nextTick(() => {
+      stream.end(buf);
+    });
+    return stream;
+  });
+};
+
+// Skip Fastify encapsulation so the hook applies to all routes
+// This is equivalent to wrapping with fastify-plugin but without the dependency
+// biome-ignore lint/suspicious/noExplicitAny: Fastify plugin metadata
+(plugin as any)[Symbol.for('skip-override')] = true;
+
+export const comprs = plugin;

--- a/packages/middleware/src/hono.ts
+++ b/packages/middleware/src/hono.ts
@@ -26,6 +26,15 @@ function compressBuffer(encoding: Encoding, data: Uint8Array, level?: LevelOptio
   }
 }
 
+function shouldSkip(c: Context, filter?: (c: Context) => boolean): boolean {
+  if (c.res.headers.has('content-encoding')) return true;
+  const cacheControl = c.res.headers.get('cache-control');
+  if (cacheControl?.includes('no-transform')) return true;
+  if (filter && !filter(c)) return true;
+  if (!isCompressibleType(c.res.headers.get('content-type') ?? undefined)) return true;
+  return false;
+}
+
 /**
  * Hono compression middleware.
  *
@@ -60,13 +69,14 @@ export function comprs(options: HonoComprsOptions = {}): MiddlewareHandler {
     c.header('Vary', appendVary(c.res.headers.get('vary') ?? undefined));
 
     if (!encoding) return;
+    if (shouldSkip(c, filter)) return;
 
-    // Skip conditions
-    if (c.res.headers.has('content-encoding')) return;
-    const cacheControl = c.res.headers.get('cache-control');
-    if (cacheControl?.includes('no-transform')) return;
-    if (filter && !filter(c)) return;
-    if (!isCompressibleType(c.res.headers.get('content-type') ?? undefined)) return;
+    // Early threshold check via Content-Length to avoid reading the body
+    const contentLength = c.res.headers.get('content-length');
+    if (contentLength) {
+      const len = Number.parseInt(contentLength, 10);
+      if (Number.isFinite(len) && len < threshold) return;
+    }
 
     // Clone before reading body so we can fall back to original if below threshold
     const cloned = c.res.clone();
@@ -75,10 +85,8 @@ export function comprs(options: HonoComprsOptions = {}): MiddlewareHandler {
 
     if (data.length < threshold) return;
 
-    // Compress
     const compressed = compressBuffer(encoding, data, level);
 
-    // Build new response with compressed body
     const headers = new Headers(c.res.headers);
     headers.set('Content-Encoding', encoding);
     headers.delete('Content-Length');

--- a/packages/middleware/src/hono.ts
+++ b/packages/middleware/src/hono.ts
@@ -1,0 +1,92 @@
+import { brotliCompress, deflateCompress, gzipCompress, zstdCompress } from '@derodero24/comprs';
+import type { Context, MiddlewareHandler } from 'hono';
+
+import { negotiate } from './negotiate.js';
+import { appendVary, DEFAULT_ENCODINGS, DEFAULT_THRESHOLD, isCompressibleType } from './shared.js';
+import type { Encoding, LevelOptions } from './types.js';
+
+/** Hono-specific options (filter receives Hono Context). */
+export interface HonoComprsOptions {
+  encodings?: Encoding[];
+  threshold?: number;
+  level?: LevelOptions;
+  filter?: (c: Context) => boolean;
+}
+
+function compressBuffer(encoding: Encoding, data: Uint8Array, level?: LevelOptions): Buffer {
+  switch (encoding) {
+    case 'zstd':
+      return zstdCompress(data, level?.zstd);
+    case 'br':
+      return brotliCompress(data, level?.br);
+    case 'gzip':
+      return gzipCompress(data, level?.gzip);
+    case 'deflate':
+      return deflateCompress(data, level?.deflate);
+  }
+}
+
+/**
+ * Hono compression middleware.
+ *
+ * Uses synchronous compression since Hono processes the response body at once
+ * via the Web Standards Response API.
+ *
+ * @example
+ * ```ts
+ * import { Hono } from 'hono';
+ * import { comprs } from '@derodero24/comprs-middleware/hono';
+ *
+ * const app = new Hono();
+ * app.use(comprs({ encodings: ['zstd', 'br', 'gzip'] }));
+ * ```
+ */
+export function comprs(options: HonoComprsOptions = {}): MiddlewareHandler {
+  const {
+    encodings = [...DEFAULT_ENCODINGS] as Encoding[],
+    threshold = DEFAULT_THRESHOLD,
+    level,
+    filter,
+  } = options;
+
+  return async (c, next) => {
+    await next();
+
+    if (c.req.method === 'HEAD') return;
+
+    const encoding = negotiate(c.req.header('accept-encoding'), encodings);
+
+    // Always set Vary
+    c.header('Vary', appendVary(c.res.headers.get('vary') ?? undefined));
+
+    if (!encoding) return;
+
+    // Skip conditions
+    if (c.res.headers.has('content-encoding')) return;
+    const cacheControl = c.res.headers.get('cache-control');
+    if (cacheControl?.includes('no-transform')) return;
+    if (filter && !filter(c)) return;
+    if (!isCompressibleType(c.res.headers.get('content-type') ?? undefined)) return;
+
+    // Clone before reading body so we can fall back to original if below threshold
+    const cloned = c.res.clone();
+    const body = await cloned.arrayBuffer();
+    const data = new Uint8Array(body);
+
+    if (data.length < threshold) return;
+
+    // Compress
+    const compressed = compressBuffer(encoding, data, level);
+
+    // Build new response with compressed body
+    const headers = new Headers(c.res.headers);
+    headers.set('Content-Encoding', encoding);
+    headers.delete('Content-Length');
+
+    c.res = new Response(compressed, {
+      status: c.res.status,
+      statusText: c.res.statusText,
+      headers,
+    });
+  };
+}

--- a/packages/middleware/src/hono.ts
+++ b/packages/middleware/src/hono.ts
@@ -29,7 +29,7 @@ function compressBuffer(encoding: Encoding, data: Uint8Array, level?: LevelOptio
 function shouldSkip(c: Context, filter?: (c: Context) => boolean): boolean {
   if (c.res.headers.has('content-encoding')) return true;
   const cacheControl = c.res.headers.get('cache-control');
-  if (cacheControl?.includes('no-transform')) return true;
+  if (cacheControl?.toLowerCase().includes('no-transform')) return true;
   if (filter && !filter(c)) return true;
   if (!isCompressibleType(c.res.headers.get('content-type') ?? undefined)) return true;
   return false;
@@ -61,13 +61,12 @@ export function comprs(options: HonoComprsOptions = {}): MiddlewareHandler {
   return async (c, next) => {
     await next();
 
+    // Always set Vary, even for HEAD requests
+    c.header('Vary', appendVary(c.res.headers.get('vary') ?? undefined));
+
     if (c.req.method === 'HEAD') return;
 
     const encoding = negotiate(c.req.header('accept-encoding'), encodings);
-
-    // Always set Vary
-    c.header('Vary', appendVary(c.res.headers.get('vary') ?? undefined));
-
     if (!encoding) return;
     if (shouldSkip(c, filter)) return;
 
@@ -78,23 +77,27 @@ export function comprs(options: HonoComprsOptions = {}): MiddlewareHandler {
       if (Number.isFinite(len) && len < threshold) return;
     }
 
-    // Clone before reading body so we can fall back to original if below threshold
-    const cloned = c.res.clone();
-    const body = await cloned.arrayBuffer();
-    const data = new Uint8Array(body);
+    // Clone before reading body so we can fall back to original on error or below threshold
+    try {
+      const cloned = c.res.clone();
+      const body = await cloned.arrayBuffer();
+      const data = new Uint8Array(body);
 
-    if (data.length < threshold) return;
+      if (data.length < threshold) return;
 
-    const compressed = compressBuffer(encoding, data, level);
+      const compressed = compressBuffer(encoding, data, level);
 
-    const headers = new Headers(c.res.headers);
-    headers.set('Content-Encoding', encoding);
-    headers.delete('Content-Length');
+      const headers = new Headers(c.res.headers);
+      headers.set('Content-Encoding', encoding);
+      headers.delete('Content-Length');
 
-    c.res = new Response(compressed, {
-      status: c.res.status,
-      statusText: c.res.statusText,
-      headers,
-    });
+      c.res = new Response(compressed, {
+        status: c.res.status,
+        statusText: c.res.statusText,
+        headers,
+      });
+    } catch {
+      // Compression failed — fall back to original unmodified response
+    }
   };
 }

--- a/packages/middleware/src/index.ts
+++ b/packages/middleware/src/index.ts
@@ -1,3 +1,2 @@
-export { comprs } from './middleware.js';
 export { negotiate } from './negotiate.js';
 export type { ComprsOptions, Encoding, LevelOptions } from './types.js';

--- a/packages/middleware/src/shared.ts
+++ b/packages/middleware/src/shared.ts
@@ -21,6 +21,7 @@ export function isCompressibleType(contentType: string | undefined): boolean {
 /** Append Accept-Encoding to a Vary header value. Returns the new Vary value. */
 export function appendVary(current: string | undefined): string {
   if (!current) return 'Accept-Encoding';
+  if (current.trim() === '*') return '*';
   if (current.toLowerCase().includes('accept-encoding')) return current;
   return `${current}, Accept-Encoding`;
 }

--- a/packages/middleware/src/shared.ts
+++ b/packages/middleware/src/shared.ts
@@ -1,0 +1,26 @@
+export const DEFAULT_THRESHOLD = 1024;
+export const DEFAULT_ENCODINGS = ['zstd', 'br', 'gzip', 'deflate'] as const;
+
+/** Check if a Content-Type is compressible. Returns false for missing Content-Type. */
+export function isCompressibleType(contentType: string | undefined): boolean {
+  if (!contentType) return false;
+  const ct = contentType.split(';')[0]?.trim().toLowerCase() ?? '';
+  if (ct.startsWith('text/')) return true;
+  if (ct === 'application/json') return true;
+  if (ct === 'application/javascript') return true;
+  if (ct === 'application/xml') return true;
+  if (ct === 'application/xhtml+xml') return true;
+  if (ct === 'application/rss+xml') return true;
+  if (ct === 'application/atom+xml') return true;
+  if (ct === 'application/graphql-response+json') return true;
+  if (ct === 'image/svg+xml') return true;
+  if (ct.endsWith('+json') || ct.endsWith('+xml')) return true;
+  return false;
+}
+
+/** Append Accept-Encoding to a Vary header value. Returns the new Vary value. */
+export function appendVary(current: string | undefined): string {
+  if (!current) return 'Accept-Encoding';
+  if (current.toLowerCase().includes('accept-encoding')) return current;
+  return `${current}, Accept-Encoding`;
+}

--- a/packages/middleware/tsconfig.json
+++ b/packages/middleware/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["ES2023"],
     "module": "Node16",
     "moduleResolution": "Node16",
+    "rootDir": "src",
     "outDir": "dist",
     "declaration": true,
     "strict": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,12 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      fastify:
+        specifier: ^5.0.0
+        version: 5.8.4
+      hono:
+        specifier: ^4.0.0
+        version: 4.12.12
       typescript:
         specifier: ^6.0.0
         version: 6.0.2
@@ -357,6 +363,24 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@fastify/ajv-compiler@4.0.5':
+    resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/error@4.2.0':
+    resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+
+  '@fastify/forwarded@3.0.1':
+    resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/proxy-addr@5.1.0':
+    resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
 
   '@inquirer/ansi@2.0.5':
     resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
@@ -940,6 +964,9 @@ packages:
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
   '@playwright/test@1.59.1':
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
@@ -1148,9 +1175,20 @@ packages:
   '@vitest/utils@4.1.4':
     resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
+  abstract-logging@2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -1200,6 +1238,13 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
+  avvio@9.2.0:
+    resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
 
   axios@1.13.6:
     resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
@@ -1341,6 +1386,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cosmiconfig-typescript-loader@6.2.0:
     resolution: {integrity: sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==}
     engines: {node: '>=v18'}
@@ -1378,6 +1427,10 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -1490,12 +1543,21 @@ packages:
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-json-stringify@6.3.0:
+    resolution: {integrity: sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==}
+
+  fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -1508,6 +1570,9 @@ packages:
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
+
+  fastify@5.8.4:
+    resolution: {integrity: sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1531,6 +1596,10 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  find-my-way@9.5.0:
+    resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
+    engines: {node: '>=20'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -1637,6 +1706,10 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
+  hono@4.12.12:
+    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+    engines: {node: '>=16.9.0'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -1676,6 +1749,10 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  ipaddr.js@2.3.0:
+    resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
+    engines: {node: '>= 10'}
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -1751,6 +1828,9 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-ref-resolver@3.0.0:
+    resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -1813,6 +1893,9 @@ packages:
   lefthook@2.1.5:
     resolution: {integrity: sha512-yB9IFWurFllusbPZqvG0EavTmpNXPya2MuO7Li7YT78xAj3uCQ3AgmW9TVUbTTsSMhsegbiAMRpwfEk2TP1P0A==}
     hasBin: true
+
+  light-my-request@6.6.0:
+    resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -2027,6 +2110,10 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -2132,6 +2219,16 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
     engines: {node: '>=18'}
@@ -2150,6 +2247,12 @@ packages:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+
+  process-warning@4.0.1:
+    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -2173,6 +2276,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -2184,6 +2290,10 @@ packages:
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -2201,9 +2311,16 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rolldown@1.0.0-rc.15:
     resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
@@ -2221,8 +2338,19 @@ packages:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
 
+  safe-regex2@5.1.0:
+    resolution: {integrity: sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw==}
+    hasBin: true
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -2236,6 +2364,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -2279,12 +2410,19 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -2330,6 +2468,10 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -2352,6 +2494,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -2912,6 +3058,29 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@fastify/ajv-compiler@4.0.5':
+    dependencies:
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fast-uri: 3.1.0
+
+  '@fastify/error@4.2.0': {}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    dependencies:
+      fast-json-stringify: 6.3.0
+
+  '@fastify/forwarded@3.0.1': {}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    dependencies:
+      dequal: 2.0.3
+
+  '@fastify/proxy-addr@5.1.0':
+    dependencies:
+      '@fastify/forwarded': 3.0.1
+      ipaddr.js: 2.3.0
+
   '@inquirer/ansi@2.0.5': {}
 
   '@inquirer/checkbox@5.1.3(@types/node@24.12.2)':
@@ -3409,6 +3578,8 @@ snapshots:
 
   '@oxc-project/types@0.124.0': {}
 
+  '@pinojs/redact@0.4.0': {}
+
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
@@ -3589,10 +3760,16 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  abstract-logging@2.0.1: {}
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
 
   ajv@8.18.0:
     dependencies:
@@ -3636,6 +3813,13 @@ snapshots:
       js-tokens: 10.0.0
 
   asynckit@0.4.0: {}
+
+  atomic-sleep@1.0.0: {}
+
+  avvio@9.2.0:
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastq: 1.20.1
 
   axios@1.13.6:
     dependencies:
@@ -3780,6 +3964,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cookie@1.1.1: {}
+
   cosmiconfig-typescript-loader@6.2.0(@types/node@24.12.2)(cosmiconfig@9.0.1(typescript@6.0.2))(typescript@6.0.2):
     dependencies:
       '@types/node': 24.12.2
@@ -3809,6 +3995,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
+
+  dequal@2.0.3: {}
 
   detect-indent@6.1.0: {}
 
@@ -3921,6 +4109,8 @@ snapshots:
 
   fast-content-type-parse@3.0.0: {}
 
+  fast-decode-uri-component@1.0.1: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -3930,6 +4120,19 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-json-stringify@6.3.0:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.2.1
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fast-uri: 3.1.0
+      json-schema-ref-resolver: 3.0.0
+      rfdc: 1.4.1
+
+  fast-querystring@1.1.2:
+    dependencies:
+      fast-decode-uri-component: 1.0.1
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -3942,6 +4145,24 @@ snapshots:
   fast-wrap-ansi@0.2.0:
     dependencies:
       fast-string-width: 3.0.2
+
+  fastify@5.8.4:
+    dependencies:
+      '@fastify/ajv-compiler': 4.0.5
+      '@fastify/error': 4.2.0
+      '@fastify/fast-json-stringify-compiler': 5.0.3
+      '@fastify/proxy-addr': 5.1.0
+      abstract-logging: 2.0.1
+      avvio: 9.2.0
+      fast-json-stringify: 6.3.0
+      find-my-way: 9.5.0
+      light-my-request: 6.6.0
+      pino: 10.3.1
+      process-warning: 5.0.0
+      rfdc: 1.4.1
+      secure-json-parse: 4.1.0
+      semver: 7.7.4
+      toad-cache: 3.7.0
 
   fastq@1.20.1:
     dependencies:
@@ -3967,6 +4188,12 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  find-my-way@9.5.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-querystring: 1.1.2
+      safe-regex2: 5.1.0
 
   find-up@4.1.0:
     dependencies:
@@ -4075,6 +4302,8 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
+  hono@4.12.12: {}
+
   html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
@@ -4107,6 +4336,8 @@ snapshots:
   ini@4.1.1: {}
 
   ipaddr.js@1.9.1: {}
+
+  ipaddr.js@2.3.0: {}
 
   is-arrayish@0.2.1: {}
 
@@ -4164,6 +4395,10 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-ref-resolver@3.0.0:
+    dependencies:
+      dequal: 2.0.3
+
   json-schema-traverse@1.0.0: {}
 
   json-with-bigint@3.5.8: {}
@@ -4214,6 +4449,12 @@ snapshots:
       lefthook-openbsd-x64: 2.1.5
       lefthook-windows-arm64: 2.1.5
       lefthook-windows-x64: 2.1.5
+
+  light-my-request@6.6.0:
+    dependencies:
+      cookie: 1.1.1
+      process-warning: 4.0.1
+      set-cookie-parser: 2.7.2
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -4375,6 +4616,8 @@ snapshots:
 
   obug@2.1.1: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -4458,6 +4701,26 @@ snapshots:
 
   pify@4.0.1: {}
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.0.0
+
   playwright-core@1.59.1: {}
 
   playwright@1.59.1:
@@ -4473,6 +4736,10 @@ snapshots:
       source-map-js: 1.2.1
 
   prettier@2.8.8: {}
+
+  process-warning@4.0.1: {}
+
+  process-warning@5.0.0: {}
 
   proxy-addr@2.0.7:
     dependencies:
@@ -4496,6 +4763,8 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  quick-format-unescaped@4.0.4: {}
+
   range-parser@1.2.1: {}
 
   raw-body@3.0.2:
@@ -4512,6 +4781,8 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
+  real-require@0.2.0: {}
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -4520,7 +4791,11 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
+  ret@0.5.0: {}
+
   reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
 
   rolldown@1.0.0-rc.15:
     dependencies:
@@ -4561,7 +4836,15 @@ snapshots:
     dependencies:
       mri: 1.2.0
 
+  safe-regex2@5.1.0:
+    dependencies:
+      ret: 0.5.0
+
+  safe-stable-stringify@2.5.0: {}
+
   safer-buffer@2.1.2: {}
+
+  secure-json-parse@4.1.0: {}
 
   semver@7.7.4: {}
 
@@ -4589,6 +4872,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.2: {}
 
   setprototypeof@1.2.0: {}
 
@@ -4636,12 +4921,18 @@ snapshots:
 
   slash@3.0.0: {}
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
 
   spawndamnit@3.0.1:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
 
@@ -4682,6 +4973,10 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  thread-stream@4.0.0:
+    dependencies:
+      real-require: 0.2.0
+
   tinybench@2.9.0: {}
 
   tinyexec@1.0.4: {}
@@ -4698,6 +4993,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
 


### PR DESCRIPTION
## Summary

Restructure `@derodero24/comprs-middleware` from Express-only to multi-framework with subpath exports:

- `@derodero24/comprs-middleware/express` — Express/Connect middleware
- `@derodero24/comprs-middleware/fastify` — Fastify plugin (`onSend` hook with stream compression)
- `@derodero24/comprs-middleware/hono` — Hono middleware (sync compression via Web Standards Response API)
- `@derodero24/comprs-middleware` — shared utilities (`negotiate`, types)

### Architecture

```
src/
├── shared.ts      ← Framework-agnostic (isCompressibleType, appendVary, constants)
├── negotiate.ts   ← Accept-Encoding negotiation
├── compress.ts    ← encoding → Transform stream mapping
├── types.ts       ← Shared types
├── index.ts       ← Root export (negotiate, types)
├── express.ts     ← Express adapter (res.write/end patching)
├── fastify.ts     ← Fastify plugin (onSend hook, skip-override)
└── hono.ts        ← Hono middleware (Response clone + sync compress)
```

### Test coverage

53 tests across 4 files:
- negotiate: 14 tests
- Express: 17 tests (unchanged)
- Fastify: 10 tests
- Hono: 12 tests

## Related issue

Closes #369

## Checklist

- [x] Changeset included
- [x] All 53 tests pass
- [x] TypeScript strict mode — no errors
- [x] Biome lint — no errors (warnings only: cognitive complexity)
- [x] Multi-framework README with subpath import examples
- [x] Root README updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Express／Fastify／Hono向けの個別サブパス（/express、/fastify、/hono）アダプターを追加しました。
  * 共有ユーティリティ（既定のエンコーディング／閾値、ヘッダ処理、可否判定等）を公開しました。

* **公開API**
  * ルートインポートはフレームワーク固有ミドルウェアではなく、交渉ユーティリティと型情報を公開するようになりました。

* **ドキュメント**
  * READMEと利用例を各フレームワーク向けに分離・更新し、共通オプションと挙動を明確化しました。

* **テスト**
  * FastifyおよびHono向けの圧縮挙動テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->