### PR TITLE
fix(ci): add post-release merge-back from main to develop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -376,3 +376,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # ──── Merge main back into develop to prevent divergence ────
+  merge-back:
+    name: Merge Back
+    needs: [publish, publish-middleware]
+    if: always() && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge main into develop
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          git merge origin/main --no-edit || {
+            echo "Merge conflict detected — creating PR for manual resolution"
+            exit 1
+          }
+          git push origin develop


### PR DESCRIPTION
## Summary

Add a `merge-back` job to the release workflow that automatically merges `main` back into `develop` after publishing.

### Problem

Each release squash-merges develop→main, creating a unique commit on main that doesn't exist on develop. Over successive releases, this causes growing merge conflicts when creating the next release PR. Today's release (#368) required manual resolution of 7 conflicting files.

### Solution

```
Before (diverging):
  develop: A → B → C → D    ← next release PR conflicts with X
  main:    A ──────── → X   ← squash commit

After (aligned):
  develop: A → B → C → D → M   ← merge commit keeps histories aligned
  main:    A ──────── → X ↗    ← next release PR is clean
```

The `merge-back` job:
- Runs after `publish` and `publish-middleware` complete (via `if: always()`)
- Only runs on `main` branch pushes
- Uses merge commit (not squash) to preserve history connection
- Falls with clear error if unexpected conflicts arise

## Related issue

Closes #374

## Checklist

- [x] No code changes — changeset not required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他の改善**
  * リリース公開時に、メインブランチの変更を開発ブランチに自動的にマージするワークフローを追加しました。これによりブランチ間の同期がより効率的になり、開発プロセスが改善されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->