### PR TITLE
chore!: drop Node.js 20 support and bump napi ABI to napi9

### DIFF
--- a/.changeset/drop-node-20-napi9.md
+++ b/.changeset/drop-node-20-napi9.md
@@ -1,0 +1,11 @@
+---
+'@derodero24/comprs': major
+---
+
+Drop Node.js 20 support and bump napi ABI to napi9.
+
+Node.js 20 reached end-of-life on 2026-04-30. The minimum supported Node.js
+version is now 22 (Active LTS). The napi-rs ABI feature has been bumped from
+`napi6` to `napi9` (Node 18.17+ / 20.3+), which is safe under the new floor.
+
+**Breaking change:** Users on Node.js 20 must upgrade to Node.js 22 or later.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
+        node: [22, 24]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/derodero24/comprs"
 
 [workspace.dependencies]
 # napi-rs
-napi = { version = "3", default-features = false, features = ["napi6"] }
+napi = { version = "3", default-features = false, features = ["napi9"] }
 napi-build = "2"
 napi-derive = { version = "3", default-features = false, features = ["type-def"] }
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Rust-powered universal compression for JavaScript/TypeScript.
 [![codecov](https://codecov.io/gh/derodero24/comprs/graph/badge.svg)](https://codecov.io/gh/derodero24/comprs)
 [![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json&repo=derodero24/comprs)](https://codspeed.io/derodero24/comprs)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-ready-blue)](https://www.typescriptlang.org/)
 [![Playground](https://img.shields.io/badge/playground-try%20it%20live-8b5cf6)](https://derodero24.github.io/comprs/)
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     ]
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "packageManager": "pnpm@10.33.0",
   "scripts": {


### PR DESCRIPTION
## Summary

- Remove Node 20 from CI test matrix (Node 20 hit EOL on 2026-04-30).
- Raise `engines.node` to `>=22.0.0`.
- Bump napi-rs ABI feature from `napi6` to `napi9` (Node 18.17+ / 20.3+).
- Update README badge to `>=22`.

**Breaking change:** minimum supported Node.js is now 22.

Closes #384

## Test plan

- [ ] CI passes on Node 22 and Node 24 across ubuntu/macos/windows
- [ ] WASM, Deno, Bun jobs still green
- [ ] Major changeset present so the next release is `2.0.0`