### PR TITLE
chore(renovate): skip stability days for GitHub Actions digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,8 @@
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "pinDigests": true,
-      "automerge": true
+      "automerge": true,
+      "minimumReleaseAge": "0 days"
     },
     {
       "description": "Group Rust crate updates",


### PR DESCRIPTION
## Summary

- Override `minimumReleaseAge` to `0 days` for the `github-actions` manager.
- The global 3-day age guards npm/cargo supply-chain risk; pinning a GitHub Action SHA forward to a newer commit on an already-trusted tag has no analogous risk.
- This unblocks the automerge rule that already exists for `github-actions` non-major updates (PR #379 had to be manually merged today because of this).

Closes #385

## Test plan

- [ ] Lint / config validation passes
- [ ] Next github-actions digest PR created by Renovate automerges without waiting 3 days