### PR TITLE
chore: sync engines.node and docs to >=22

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing! This guide covers everything you ne
 ## Prerequisites
 
 - [Rust](https://rustup.rs/) ≥ 1.85 (stable toolchain)
-- [Node.js](https://nodejs.org/) ≥ 20
+- [Node.js](https://nodejs.org/) ≥ 22
 - [pnpm](https://pnpm.io/) ≥ 10
 - [Git](https://git-scm.com/)
 

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ await pipeline(
 
 | Platform | Backend | Status |
 | --- | --- | --- |
-| Node.js ≥ 20 | Native (napi-rs) | ✅ |
+| Node.js ≥ 22 | Native (napi-rs) | ✅ |
 | Browsers | WASM | ✅ |
 | Deno | WASM | ✅ |
 | Bun | WASM | ✅ |

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/derodero24/comprs",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/derodero24/comprs",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/derodero24/comprs",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/derodero24/comprs",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/derodero24/comprs",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/derodero24/comprs",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/derodero24/comprs",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/derodero24/comprs",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -59,7 +59,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary

PR #386 raised the root `engines.node` to `>=22.0.0` but missed several places that still advertise Node.js 20. Sync them so v2.0.0 ships consistent metadata.

- [`README.md`](README.md#L409): Platform Support table → `Node.js ≥ 22`
- [`CONTRIBUTING.md`](CONTRIBUTING.md#L8): prerequisites → `Node.js ≥ 22`
- [`packages/middleware/package.json`](packages/middleware/package.json#L62): `engines.node: ">=22.0.0"`
- 8x [`npm/<platform>/package.json`](npm/): `engines.node: ">=22.0.0"` (`napi version` preserves the existing field rather than regenerating from root, so this one-time sync is required)
- `wasm32-wasi` keeps `>=14.0.0` since it doesn't depend on N-API

If we ship 2.0 with the stale `>=20.0.0`, npm clients on Node 20 install the package without warning even though the native `napi9` binding requires Node 22.

Closes #406

## Test plan

- [ ] CI green
- [ ] Release PR #388 rebases cleanly and picks these up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **変更**
  * Node.js の最小要件バージョンが 20.0.0 以上から 22.0.0 以上に更新されました。この変更は、ドキュメンテーション、プラットフォームサポート情報、および全てのプラットフォーム向けパッケージ構成に反映されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->