### PR TITLE
fix(ci): prevent Browser WASM Test hang on Playwright install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,7 +395,18 @@ jobs:
           name: bindings-wasm-bindgen
           path: .
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        timeout-minutes: 10
+        run: |
+          for attempt in 1 2 3; do
+            echo "Playwright install attempt ${attempt}/3"
+            if pnpm exec playwright install --with-deps chromium; then
+              exit 0
+            fi
+            echo "Playwright install failed (attempt ${attempt}); retrying..."
+            sleep 5
+          done
+          echo "Playwright install failed after 3 attempts"
+          exit 1
       - name: Run browser tests
         run: pnpm run test:browser
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,18 +394,33 @@ jobs:
         with:
           name: bindings-wasm-bindgen
           path: .
-      - name: Install Playwright browsers
-        timeout-minutes: 10
+      - name: Resolve Playwright version
+        id: playwright
+        run: echo "version=$(pnpm exec playwright --version | grep -oE '[0-9.]+')" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+      - name: Install Playwright system dependencies
+        run: pnpm exec playwright install-deps chromium
+      - name: Install Playwright browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 12
         run: |
           for attempt in 1 2 3; do
-            echo "Playwright install attempt ${attempt}/3"
-            if pnpm exec playwright install --with-deps chromium; then
+            echo "Playwright browser install attempt ${attempt}/3"
+            # Bound each attempt so a stalled download/extraction is killed and
+            # retried, instead of hanging until the step timeout fires.
+            if timeout 180 pnpm exec playwright install chromium; then
               exit 0
             fi
-            echo "Playwright install failed (attempt ${attempt}); retrying..."
+            echo "Playwright browser install failed or timed out (attempt ${attempt}); retrying..."
+            rm -rf ~/.cache/ms-playwright
             sleep 5
           done
-          echo "Playwright install failed after 3 attempts"
+          echo "Playwright browser install failed after 3 attempts"
           exit 1
       - name: Run browser tests
         run: pnpm run test:browser


### PR DESCRIPTION
## Summary

The `Browser WASM Test` job intermittently hangs during `playwright install --with-deps chromium`: the Chrome-for-Testing archive downloads to 100%, then the install step stalls with no further output until the 6-hour job timeout cancels it. Because this job feeds the `CI Complete` aggregate gate, a single hang turns the whole pipeline red — this currently affects `develop` itself and most open dependency-update PRs.

This caps the install step with a 10-minute timeout so a hang fails fast instead of burning 6 hours, retries up to 3 times to absorb transient install failures, and uses the pinned Playwright CLI via `pnpm exec` instead of `npx` to avoid an unpinned re-resolve.

## Related issue

Closes #419

## Checklist

- [x] CI workflow only — no library code change
- [x] No changeset needed (CI `chore`, no `src/` or `crates/` change)
- [x] Indentation matches surrounding steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * テスト実行の安定性を向上するため、ブラウザ導入手順を段階化し、バージョン解決・ブラウザキャッシュ活用・システム依存導入を分離しました。  
  * キャッシュヒット時はインストールをスキップし、キャッシュミス時はタイムアウト付きリトライ（最大3回）で導入を試行します。  
  * ジョブのタイムアウトを12分に設定しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->