### PR TITLE
chore(deps): upgrade pnpm 10 to 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   "engines": {
     "node": ">=22.0.0"
   },
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@11.6.0",
   "scripts": {
     "build": "napi build --manifest-path crates/core/Cargo.toml --platform --release --js index.js --dts index.d.ts --output-dir .",
     "build:debug": "napi build --manifest-path crates/core/Cargo.toml --platform --js index.js --dts index.d.ts --output-dir .",
@@ -164,21 +164,6 @@
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
     "vitest": "^4.1.8"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "lefthook"
-    ],
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "@codspeed/vitest-plugin>vite": "8"
-      }
-    },
-    "overrides": {
-      "emnapi": "1.11.0",
-      "es-toolkit": "1.47.0",
-      "form-data": "4.0.5"
-    }
   },
   "publishConfig": {
     "access": "public",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   emnapi: 1.11.0
   es-toolkit: 1.47.0
   form-data: 4.0.5
+  obug: 2.1.2
 
 importers:
 
@@ -2165,11 +2166,8 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
-  obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
-
-  obug@2.1.3:
-    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+  obug@2.1.2:
+    resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
     engines: {node: '>=12.20.0'}
 
   on-exit-leak-free@2.1.2:
@@ -3392,7 +3390,7 @@ snapshots:
       emnapi: 1.11.0
       es-toolkit: 1.47.0
       js-yaml: 4.2.0
-      obug: 2.1.3
+      obug: 2.1.2
       semver: 7.8.4
       typanion: 3.14.0
     optionalDependencies:
@@ -3870,7 +3868,7 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.3
-      obug: 2.1.3
+      obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
       vitest: 4.1.5(@types/node@25.9.3)(@vitest/coverage-v8@4.1.5)(vite@8.0.16(@types/node@25.9.3)(jiti@2.6.1))
@@ -3885,7 +3883,7 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.3
-      obug: 2.1.3
+      obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
       vitest: 4.1.8(@types/node@24.13.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@24.13.2)(jiti@2.6.1))
@@ -4837,9 +4835,7 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  obug@2.1.1: {}
-
-  obug@2.1.3: {}
+  obug@2.1.2: {}
 
   on-exit-leak-free@2.1.2: {}
 
@@ -5308,7 +5304,7 @@ snapshots:
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.2
       pathe: 2.0.3
       picomatch: 4.0.4
       std-env: 4.1.0
@@ -5336,7 +5332,7 @@ snapshots:
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.3
+      obug: 2.1.2
       pathe: 2.0.3
       picomatch: 4.0.4
       std-env: 4.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,13 @@
 packages:
   - '.'
   - 'packages/*'
+allowBuilds:
+  lefthook: true
+peerDependencyRules:
+  allowedVersions:
+    '@codspeed/vitest-plugin>vite': '8'
+overrides:
+  emnapi: 1.11.0
+  es-toolkit: 1.47.0
+  form-data: 4.0.5
+  obug: 2.1.2


### PR DESCRIPTION
## Summary

Upgrade the package manager from pnpm 10 to **pnpm 11.6.0**, isolated in its own PR because it touches the workspace config layout and the supply-chain policy.

### Changes

- `packageManager`: `pnpm@10.33.2` → `pnpm@11.6.0`.
- **Migrate the `pnpm` field out of package.json** into `pnpm-workspace.yaml`. pnpm 11 no longer reads `pnpm.*` from package.json (it warns and ignores `onlyBuiltDependencies`, `peerDependencyRules`, `overrides`), so those settings move to their new home.
- Add `obug` to the aged-version overrides (alongside the existing `emnapi`/`es-toolkit`/`form-data` pins from #431) so the lockfile satisfies pnpm 11's minimum-release-age supply-chain policy without needing a `minimumReleaseAgeExclude` entry.

`pnpm/action-setup` reads `packageManager`, so CI uses pnpm 11 automatically — no workflow edit required.

### Notes

- The lockfile stays at `lockfileVersion: '9.0'` — pnpm 11.6 does not migrate the format, so this is lower-risk than a format change.
- pnpm 11's Node floor is 22, already satisfied (`engines.node >=22`).
- This upgrade is effectively one-way (downgrading to pnpm 10 afterwards fails with `ERR_PNPM_BROKEN_LOCKFILE`).

## Verification

- `pnpm install --frozen-lockfile` validates under pnpm 11
- **Supply-chain policy: ✓ passes** (no exclusions needed)
- `pnpm run check` / `typecheck` / `test` (459 passed) / `build:debug` all green under pnpm 11; `browser.js` re-patched after build

## Related issue

Closes #428

## Checklist

- [x] `pnpm` settings migrated to pnpm-workspace.yaml and still honored
- [x] No changeset (tooling chore, no `src/`/`crates/` or shipped-runtime change)