### PR TITLE
chore(deps): group emnapi family updates in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,11 @@
       "groupName": "rust-dependencies"
     },
     {
+      "description": "Group emnapi family updates (napi-rs's WASI build requires them to stay version-locked)",
+      "matchPackageNames": ["emnapi", "@emnapi/core", "@emnapi/runtime"],
+      "groupName": "emnapi"
+    },
+    {
       "description": "Automerge non-major Rust crate updates",
       "matchManagers": ["cargo"],
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## Summary
- Adds a Renovate `packageRules` entry grouping `emnapi`, `@emnapi/core`, and `@emnapi/runtime` so they always update together in one PR

## Background
napi-rs's WASI build requires these three packages to resolve to the exact same version. They were previously tracked independently by Renovate, which let PR #440 bump `@emnapi/core` alone and break the `wasm32-wasip1-threads` build with an `emnapi version mismatch` error.

## Related issue
Closes #443

## Checklist
- [x] No changeset needed (config-only change, no `src/`/`crates/` code)