### PR TITLE
fix(deps): update crossbeam-epoch to resolve RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
- Bumps `crossbeam-epoch` 0.9.18 → 0.9.20 to resolve [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) (invalid pointer dereference in `fmt::Pointer`/`fmt::Display`)

## Background
This advisory was just published and started failing "Dependency Audit" on every open PR (unrelated to their own changes), since `crossbeam-epoch` is pulled in transitively via `crates/bench`'s `codspeed-criterion-compat-walltime` → `rayon` chain. This is a CI-blocking emergency fix per CLAUDE.md §4.

`crossbeam-epoch` is only reachable through the bench-only dev-dependency graph — it's not part of any published crate/binary — so no changeset is included.

## Checklist
- [x] `cargo deny check advisories` passes locally
- [x] No changeset needed (bench-only dev-dependency, not part of the published package)