### PR TITLE
chore(changeset): backfill changeset for @napi-rs/cli 3.7.2 loader regen

### DIFF
--- a/.changeset/napi-cli-3-7-2-loader-template.md
+++ b/.changeset/napi-cli-3-7-2-loader-template.md
@@ -1,0 +1,8 @@
+---
+'@derodero24/comprs': patch
+---
+
+Regenerate the napi-rs loader with `@napi-rs/cli` 3.7.2. The generated
+`index.js` drops the `node:` import prefix and optional chaining (`?.`) from
+its native-binding loader, improving compatibility with older Node.js
+versions and bundlers that don't support these syntax forms.


### PR DESCRIPTION
## Summary
- Adds the missing changeset for PR #452's `index.js` regeneration (`@napi-rs/cli` 3.7.2 loader template change)

## Background
PR #452 bumped `@napi-rs/cli` to 3.7.2 and regenerated `index.js` (drops `node:` import prefix and optional chaining for broader Node.js compatibility), but was merged as a plain dependency update without a changeset. Since this touches a file shipped in the published package, it should be documented in the CHANGELOG before the next release.

## Checklist
- [x] Changeset included (this PR's entire purpose)